### PR TITLE
Fix landing exec

### DIFF
--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -81,7 +81,7 @@ export async function getGithubExecutives(network: SupportedNetworks): Promise<C
 
   const proposals = githubProposals.map(proposal => {
     try {
-      const path = `https://raw.githubusercontent.com/${githubRepo.owner}/${githubRepo.repo}/refs/heads/${githubRepo.branch}/${proposal.path}`;
+      const path = `https://raw.githubusercontent.com/${githubRepo.owner}/${githubRepo.repo}/${githubRepo.branch}/${proposal.path}`;
       return parseExecutive(proposal, activeProposals, path, network);
     } catch (e) {
       logger.error(`getGithubExecutives: network ${network}`, e);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -39,6 +39,7 @@ import { LandingPageData } from 'modules/home/api/fetchLandingPageData';
 import { useLandingPageDelegates } from 'modules/gql/hooks/useLandingPageDelegates';
 import { useNetwork } from 'modules/app/hooks/useNetwork';
 import { parseEther } from 'viem';
+import { formatValue } from 'lib/string';
 
 const LandingPage = ({
   proposals,
@@ -69,6 +70,15 @@ const LandingPage = ({
 
   // executives
   const { data: votedProposals, mutate: mutateVotedProposals } = useVotedProposals();
+
+  const firstProposal = proposals[0];
+  const formattedFirstProposal = {
+    ...firstProposal,
+    spellData: {
+      ...firstProposal.spellData,
+      skySupport: formatValue(BigInt(firstProposal.spellData.skySupport || 0), 'wad', 2, false)
+    }
+  };
 
   // revalidate votedProposals if connected address changes
   useEffect(() => {
@@ -120,7 +130,7 @@ const LandingPage = ({
                           votedProposals={votedProposals}
                           account={account}
                           isHat={hat ? hat.toLowerCase() === proposals[0].address.toLowerCase() : false}
-                          proposal={proposals[0]}
+                          proposal={formattedFirstProposal}
                         />
                       ) : (
                         <Text>No proposals found</Text>


### PR DESCRIPTION
### What does this PR do?
- Fix an issue preventing the spell from showing in the landing page because of a mismatch in the spell GitHub URLs
- Fix the SKY amount format in the landing page spell card