### PR TITLE
Fix gasless poll vote dedupe and exclude staking-engine delegation from totals

### DIFF
--- a/modules/delegates/api/__tests__/fetchDelegationMetrics.spec.ts
+++ b/modules/delegates/api/__tests__/fetchDelegationMetrics.spec.ts
@@ -19,27 +19,39 @@ describe('fetchDelegationMetrics', () => {
     vi.clearAllMocks();
   });
 
-  it('paginates delegations and queries with the staking engine excluded', async () => {
+  it('subtracts staking engine delegations from aggregate totals', async () => {
     (gqlRequest as Mock)
       .mockResolvedValueOnce({
-        delegations: Array.from({ length: 1000 }, (_, index) => ({
-          delegator: `0x${index.toString(16).padStart(40, '0')}`,
-          delegate: { id: '1-0xdelegate', version: '3' },
-          amount: '1000000000000000000'
-        }))
+        delegates: [
+          {
+            totalDelegated: '10000000000000000000',
+            delegators: 2
+          },
+          {
+            totalDelegated: '20000000000000000000',
+            delegators: 1
+          }
+        ]
       })
       .mockResolvedValueOnce({
-        delegations: []
+        delegations: [
+          {
+            delegate: {
+              totalDelegated: '10000000000000000000',
+              delegators: 2
+            },
+            amount: '3000000000000000000'
+          }
+        ]
       });
 
     const metrics = await fetchDelegationMetrics(SupportedNetworks.MAINNET);
 
     expect(metrics).toEqual({
-      totalSkyDelegated: '1000',
-      delegatorCount: 1000
+      totalSkyDelegated: '27',
+      delegatorCount: 2
     });
     expect((gqlRequest as Mock).mock.calls).toHaveLength(2);
-    expect((gqlRequest as Mock).mock.calls[0][0].query).toContain(stakingEngineAddressMainnet);
-    expect((gqlRequest as Mock).mock.calls[1][0].query).toContain('offset: 1000');
+    expect((gqlRequest as Mock).mock.calls[1][0].query).toContain(stakingEngineAddressMainnet);
   });
 });

--- a/modules/delegates/api/__tests__/fetchDelegationMetrics.spec.ts
+++ b/modules/delegates/api/__tests__/fetchDelegationMetrics.spec.ts
@@ -1,0 +1,45 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import { Mock, vi } from 'vitest';
+import { gqlRequest } from 'modules/gql/gqlRequest';
+import { stakingEngineAddressMainnet } from 'modules/gql/gql.constants';
+import { fetchDelegationMetrics } from '../fetchDelegationMetrics';
+import { SupportedNetworks } from 'modules/web3/constants/networks';
+
+vi.mock('modules/gql/gqlRequest');
+
+describe('fetchDelegationMetrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('paginates delegations and queries with the staking engine excluded', async () => {
+    (gqlRequest as Mock)
+      .mockResolvedValueOnce({
+        delegations: Array.from({ length: 1000 }, (_, index) => ({
+          delegator: `0x${index.toString(16).padStart(40, '0')}`,
+          delegate: { id: '1-0xdelegate', version: '3' },
+          amount: '1000000000000000000'
+        }))
+      })
+      .mockResolvedValueOnce({
+        delegations: []
+      });
+
+    const metrics = await fetchDelegationMetrics(SupportedNetworks.MAINNET);
+
+    expect(metrics).toEqual({
+      totalSkyDelegated: '1000',
+      delegatorCount: 1000
+    });
+    expect((gqlRequest as Mock).mock.calls).toHaveLength(2);
+    expect((gqlRequest as Mock).mock.calls[0][0].query).toContain(stakingEngineAddressMainnet);
+    expect((gqlRequest as Mock).mock.calls[1][0].query).toContain('offset: 1000');
+  });
+});

--- a/modules/delegates/api/fetchDelegates.ts
+++ b/modules/delegates/api/fetchDelegates.ts
@@ -350,6 +350,12 @@ export async function fetchDelegatesPaginated({
       const lastVoteArbitrum = lastVotedArbitrumObj[delegate.ownerAddress.toLowerCase()] || 0;
 
       const lastVoteTimestamp = Math.max(lastVoteMainnet, lastVoteArbitrum);
+      const totalDelegated = (delegate.delegations || []).reduce(
+        (acc, curr) => acc + BigInt(curr?.amount || '0'),
+        0n
+      );
+      const hasStakingEngineDelegation = (delegate.stakingEngineDelegations || []).length > 0;
+      const delegatorCount = Math.max(0, (delegate.delegators || 0) - (hasStakingEngineDelegation ? 1 : 0));
 
       return {
         name: githubDelegate?.name || 'Shadow Delegate',
@@ -360,8 +366,8 @@ export async function fetchDelegatesPaginated({
         picture: githubDelegate?.picture,
         communication: githubDelegate?.communication,
         combinedParticipation: githubDelegate?.combinedParticipation,
-        skyDelegated: formatEther(BigInt(delegate.totalDelegated || '0')),
-        delegatorCount: delegate.delegators,
+        skyDelegated: formatEther(totalDelegated),
+        delegatorCount,
         lastVoteDate: lastVoteTimestamp > 0 ? new Date(lastVoteTimestamp * 1000) : null,
         proposalsSupported: votedProposals?.length || 0,
         execSupported: execSupported && { title: execSupported.title, address: execSupported.address }

--- a/modules/delegates/api/fetchDelegates.ts
+++ b/modules/delegates/api/fetchDelegates.ts
@@ -350,12 +350,13 @@ export async function fetchDelegatesPaginated({
       const lastVoteArbitrum = lastVotedArbitrumObj[delegate.ownerAddress.toLowerCase()] || 0;
 
       const lastVoteTimestamp = Math.max(lastVoteMainnet, lastVoteArbitrum);
-      const totalDelegated = (delegate.delegations || []).reduce(
+      const stakingEngineDelegated = (delegate.stakingEngineDelegations || []).reduce(
         (acc, curr) => acc + BigInt(curr?.amount || '0'),
         0n
       );
-      const hasStakingEngineDelegation = (delegate.stakingEngineDelegations || []).length > 0;
-      const delegatorCount = Math.max(0, (delegate.delegators || 0) - (hasStakingEngineDelegation ? 1 : 0));
+      const stakingEngineDelegatorCount = (delegate.stakingEngineDelegations || []).length;
+      const totalDelegated = BigInt(delegate.totalDelegated || '0') - stakingEngineDelegated;
+      const delegatorCount = Math.max(0, (delegate.delegators || 0) - stakingEngineDelegatorCount);
 
       return {
         name: githubDelegate?.name || 'Shadow Delegate',

--- a/modules/delegates/api/fetchDelegationMetrics.ts
+++ b/modules/delegates/api/fetchDelegationMetrics.ts
@@ -7,7 +7,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 */
 
 import { gqlRequest } from 'modules/gql/gqlRequest';
-import { allDelegationsPaginated } from 'modules/gql/queries/subgraph/allDelegations';
+import { allDelegates } from 'modules/gql/queries/subgraph/allDelegates';
+import { stakingEngineDelegations } from 'modules/gql/queries/subgraph/allDelegations';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
 import { networkNameToChainId } from 'modules/web3/helpers/chain';
 import { formatEther } from 'viem';
@@ -18,40 +19,41 @@ interface DelegationMetrics {
 }
 
 interface Delegate {
-  id: string;
-  version: string;
+  totalDelegated: string;
+  delegators: number;
 }
 
-interface Delegation {
-  delegator: string;
+interface StakingEngineDelegation {
   delegate: Delegate;
   amount: string;
 }
 
 export async function fetchDelegationMetrics(network: SupportedNetworks): Promise<DelegationMetrics> {
   const chainId = networkNameToChainId(network);
-  const pageSize = 1000;
-  let offset = 0;
-  let hasMore = true;
-  const allDelegations: Delegation[] = [];
-
-  while (hasMore) {
-    const res = await gqlRequest<{ delegations: Delegation[] }>({
+  const [delegatesRes, stakingEngineDelegationsRes] = await Promise.all([
+    gqlRequest<{ delegates: Delegate[] }>({
       chainId,
-      query: allDelegationsPaginated(chainId, pageSize, offset)
-    });
+      query: allDelegates(chainId)
+    }),
+    gqlRequest<{ delegations: StakingEngineDelegation[] }>({
+      chainId,
+      query: stakingEngineDelegations(chainId)
+    })
+  ]);
 
-    const delegations = res.delegations || [];
-    allDelegations.push(...delegations);
-
-    hasMore = delegations.length === pageSize;
-    offset += pageSize;
-  }
+  const delegates = delegatesRes.delegates || [];
+  const stakingDelegations = stakingEngineDelegationsRes.delegations || [];
+  const totalDelegated = delegates.reduce((acc, cur) => acc + BigInt(cur.totalDelegated || '0'), 0n);
+  const totalDelegators = delegates.reduce((acc, cur) => acc + (cur.delegators || 0), 0);
+  const stakingEngineDelegated = stakingDelegations.reduce(
+    (acc, cur) => acc + BigInt(cur.amount || '0'),
+    0n
+  );
 
   const totalSkyDelegated = formatEther(
-    allDelegations.reduce((acc, cur) => acc + BigInt(cur.amount || '0'), 0n)
+    totalDelegated - stakingEngineDelegated
   );
-  const delegatorCount = allDelegations.filter(delegation => BigInt(delegation.amount || '0') > 0n).length;
+  const delegatorCount = Math.max(0, totalDelegators - stakingDelegations.length);
 
   return {
     totalSkyDelegated,

--- a/modules/delegates/api/fetchDelegationMetrics.ts
+++ b/modules/delegates/api/fetchDelegationMetrics.ts
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 */
 
 import { gqlRequest } from 'modules/gql/gqlRequest';
-import { allDelegates } from 'modules/gql/queries/subgraph/allDelegates';
+import { allDelegationsPaginated } from 'modules/gql/queries/subgraph/allDelegations';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
 import { networkNameToChainId } from 'modules/web3/helpers/chain';
 import { formatEther } from 'viem';
@@ -18,25 +18,40 @@ interface DelegationMetrics {
 }
 
 interface Delegate {
-  totalDelegated: string;
-  delegators: number;
+  id: string;
+  version: string;
+}
+
+interface Delegation {
+  delegator: string;
+  delegate: Delegate;
+  amount: string;
 }
 
 export async function fetchDelegationMetrics(network: SupportedNetworks): Promise<DelegationMetrics> {
   const chainId = networkNameToChainId(network);
+  const pageSize = 1000;
+  let offset = 0;
+  let hasMore = true;
+  const allDelegations: Delegation[] = [];
 
-  const res = await gqlRequest<{ delegates: Delegate[] }>({
-    chainId,
-    query: allDelegates(chainId)
-  });
+  while (hasMore) {
+    const res = await gqlRequest<{ delegations: Delegation[] }>({
+      chainId,
+      query: allDelegationsPaginated(chainId, pageSize, offset)
+    });
 
-  const delegates = res.delegates || [];
+    const delegations = res.delegations || [];
+    allDelegations.push(...delegations);
 
-  // Sum totalDelegated and delegators across all delegates
+    hasMore = delegations.length === pageSize;
+    offset += pageSize;
+  }
+
   const totalSkyDelegated = formatEther(
-    delegates.reduce((acc, cur) => acc + BigInt(cur.totalDelegated || '0'), 0n)
+    allDelegations.reduce((acc, cur) => acc + BigInt(cur.amount || '0'), 0n)
   );
-  const delegatorCount = delegates.reduce((acc, cur) => acc + (cur.delegators || 0), 0);
+  const delegatorCount = allDelegations.filter(delegation => BigInt(delegation.amount || '0') > 0n).length;
 
   return {
     totalSkyDelegated,

--- a/modules/gql/queries/subgraph/allArbitrumVoters.ts
+++ b/modules/gql/queries/subgraph/allArbitrumVoters.ts
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 */
 
 export const allArbitrumVoters = (chainId: number, pollId: string) => /* GraphQL */ `
-{
+query allArbitrumVoters {
   arbitrumPoll: ArbitrumPoll_by_pk(id: "${chainId}-${pollId}") {
     startDate
     endDate

--- a/modules/gql/queries/subgraph/allDelegations.ts
+++ b/modules/gql/queries/subgraph/allDelegations.ts
@@ -12,21 +12,19 @@ const stakingEngineAddresses = Array.from(
   new Set([stakingEngineAddressMainnet, stakingEngineAddressTestnet])
 );
 
-export const allDelegationsPaginated = (chainId: number, limit: number, offset: number) => /* GraphQL */ `
+export const stakingEngineDelegations = (chainId: number) => /* GraphQL */ `
 {
   delegations: Delegation(
-    limit: ${limit}
-    offset: ${offset}
     where: { _and: [
       { chainId: { _eq: ${chainId} } },
       { delegate: { version: { _eq: "3" } } },
-      { delegator: { _nin: ["${stakingEngineAddresses.join('", "')}"] } }
+      { delegator: { _in: ["${stakingEngineAddresses.join('", "')}"] } },
+      { amount: { _gt: "0" } }
     ] }
   ) {
-    delegator
     delegate {
-      id
-      version
+      totalDelegated
+      delegators
     }
     amount
   }

--- a/modules/gql/queries/subgraph/allDelegations.ts
+++ b/modules/gql/queries/subgraph/allDelegations.ts
@@ -1,0 +1,34 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import { stakingEngineAddressMainnet, stakingEngineAddressTestnet } from 'modules/gql/gql.constants';
+
+const stakingEngineAddresses = Array.from(
+  new Set([stakingEngineAddressMainnet, stakingEngineAddressTestnet])
+);
+
+export const allDelegationsPaginated = (chainId: number, limit: number, offset: number) => /* GraphQL */ `
+{
+  delegations: Delegation(
+    limit: ${limit}
+    offset: ${offset}
+    where: { _and: [
+      { chainId: { _eq: ${chainId} } },
+      { delegate: { version: { _eq: "3" } } },
+      { delegator: { _nin: ["${stakingEngineAddresses.join('", "')}"] } }
+    ] }
+  ) {
+    delegator
+    delegate {
+      id
+      version
+    }
+    amount
+  }
+}
+`;

--- a/modules/gql/queries/subgraph/allMainnetVoters.ts
+++ b/modules/gql/queries/subgraph/allMainnetVoters.ts
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 */
 
 export const allMainnetVoters = (chainId: number, pollId: string) => /* GraphQL */ `
-{
+query allMainnetVoters {
   pollVotes: PollVote(
     where: { _and: [
       { chainId: { _eq: ${chainId} } },

--- a/modules/gql/queries/subgraph/delegates.ts
+++ b/modules/gql/queries/subgraph/delegates.ts
@@ -11,9 +11,6 @@ import { stakingEngineAddressMainnet, stakingEngineAddressTestnet } from 'module
 const stakingEngineAddresses = Array.from(
   new Set([stakingEngineAddressMainnet, stakingEngineAddressTestnet])
 );
-const stakingEngineExclusionFilters = stakingEngineAddresses
-  .map(address => `{ delegator: { _nilike: "${address}" } }`)
-  .join(', ');
 const stakingEngineInclusionFilters = stakingEngineAddresses
   .map(address => `{ delegator: { _ilike: "${address}" } }`)
   .join(', ');
@@ -22,18 +19,15 @@ const delegateFields = /* GraphQL */ `
   blockTimestamp
   blockNumber
   ownerAddress
-  delegations(
-    limit: 1000
+  stakingEngineDelegations: delegations(
+    limit: ${stakingEngineAddresses.length}
     where: { _and: [
-      { _and: [${stakingEngineExclusionFilters}] },
+      { _or: [${stakingEngineInclusionFilters}] },
       { amount: { _gt: "0" } }
     ] }
   ) {
     delegator
     amount
-  }
-  stakingEngineDelegations: delegations(where: { _or: [${stakingEngineInclusionFilters}] }) {
-    delegator
   }
   totalDelegated
   id

--- a/modules/gql/queries/subgraph/delegates.ts
+++ b/modules/gql/queries/subgraph/delegates.ts
@@ -6,10 +6,35 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 */
 
+import { stakingEngineAddressMainnet, stakingEngineAddressTestnet } from 'modules/gql/gql.constants';
+
+const stakingEngineAddresses = Array.from(
+  new Set([stakingEngineAddressMainnet, stakingEngineAddressTestnet])
+);
+const stakingEngineExclusionFilters = stakingEngineAddresses
+  .map(address => `{ delegator: { _nilike: "${address}" } }`)
+  .join(', ');
+const stakingEngineInclusionFilters = stakingEngineAddresses
+  .map(address => `{ delegator: { _ilike: "${address}" } }`)
+  .join(', ');
+
 const delegateFields = /* GraphQL */ `
   blockTimestamp
   blockNumber
   ownerAddress
+  delegations(
+    limit: 1000
+    where: { _and: [
+      { _and: [${stakingEngineExclusionFilters}] },
+      { amount: { _gt: "0" } }
+    ] }
+  ) {
+    delegator
+    amount
+  }
+  stakingEngineDelegations: delegations(where: { _or: [${stakingEngineInclusionFilters}] }) {
+    delegator
+  }
   totalDelegated
   id
   address

--- a/modules/gql/queries/subgraph/voteAddressSkyWeightsAtTime.ts
+++ b/modules/gql/queries/subgraph/voteAddressSkyWeightsAtTime.ts
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 export const voteAddressSkyWeightsAtTime = (chainId: number, voters: string[], unix: number) => {
   const prefixedVoters = voters.map(v => `{ id: { _ilike: "${chainId}-${v}" } }`).join(', ');
   return /* GraphQL */ `
-{
+query voteAddressSkyWeightsAtTime {
   voters: Voter(
     where: { _and: [
       { chainId: { _eq: ${chainId} } },

--- a/modules/polling/api/__tests__/fetchVotesByAddress.spec.ts
+++ b/modules/polling/api/__tests__/fetchVotesByAddress.spec.ts
@@ -1,0 +1,72 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import { Mock, vi } from 'vitest';
+import { gqlRequest } from 'modules/gql/gqlRequest';
+import { fetchVotesByAddressForPoll } from '../fetchVotesByAddress';
+import { SupportedNetworks } from 'modules/web3/constants/networks';
+
+vi.mock('modules/gql/gqlRequest');
+
+describe('fetchVotesByAddressForPoll', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('dedupes gasless votes by the mapped delegate address and keeps the delegate weight', async () => {
+    (gqlRequest as Mock)
+      .mockResolvedValueOnce({
+        pollVotes: [
+          {
+            voter: { id: '1-0xdelegate', address: '0xdelegate' },
+            choice: '1',
+            blockTime: 100,
+            txnHash: '0xmain'
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
+          votes: [
+            {
+              voter: { id: '42161-0xowner', address: '0xowner' },
+              choice: '2',
+              blockTime: 150,
+              txnHash: '0xarb'
+            }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        voters: [
+          {
+            id: '0xdelegate',
+            address: '0xdelegate',
+            v2VotingPowerChanges: [{ newBalance: '5000000000000000000' }]
+          }
+        ]
+      });
+
+    const votes = await fetchVotesByAddressForPoll(
+      123,
+      { '0xowner': '0xdelegate' },
+      SupportedNetworks.MAINNET
+    );
+
+    expect(votes).toHaveLength(1);
+    expect(votes[0]).toEqual(
+      expect.objectContaining({
+        voter: '0xdelegate',
+        hash: '0xarb',
+        skySupport: '5'
+      })
+    );
+  });
+});

--- a/modules/polling/api/fetchVotesByAddress.ts
+++ b/modules/polling/api/fetchVotesByAddress.ts
@@ -85,11 +85,12 @@ export async function fetchVotesByAddressForPoll(
     })
   ]);
 
-  const startUnix = arbitrumVotersResponse.arbitrumPoll.startDate;
-  const endUnix = arbitrumVotersResponse.arbitrumPoll.endDate;
+  const arbitrumPoll = arbitrumVotersResponse.arbitrumPoll;
+  const startUnix = arbitrumPoll?.startDate ?? Number.NEGATIVE_INFINITY;
+  const endUnix = arbitrumPoll?.endDate ?? Number.POSITIVE_INFINITY;
 
-  const mainnetVotes = mainnetVotersResponse.pollVotes;
-  const arbitrumVotes = arbitrumVotersResponse.arbitrumPoll.votes;
+  const mainnetVotes = mainnetVotersResponse.pollVotes || [];
+  const arbitrumVotes = arbitrumPoll?.votes || [];
 
   const isVoteWithinPollTimeframe = vote => vote.blockTime >= startUnix && vote.blockTime <= endUnix;
   const getVoterAddress = (voter: VoterData | VoterWithWeight) =>

--- a/modules/polling/api/fetchVotesByAddress.ts
+++ b/modules/polling/api/fetchVotesByAddress.ts
@@ -16,10 +16,11 @@ import { networkNameToChainId } from 'modules/web3/helpers/chain';
 import { parseRawOptionId } from '../helpers/parseRawOptionId';
 import { formatEther } from 'viem';
 import { SupportedChainId } from 'modules/web3/constants/chainID';
+import { stripChainIdPrefix } from 'modules/gql/gqlUtils';
 
 interface VoterData {
   id: string;
-  address: string;
+  address?: string;
 }
 
 interface VoteData {
@@ -56,7 +57,7 @@ interface VotingPowerChange {
 
 interface VoterWithWeight {
   id: string;
-  address: string;
+  address?: string;
   v2VotingPowerChanges: VotingPowerChange[];
 }
 
@@ -91,19 +92,21 @@ export async function fetchVotesByAddressForPoll(
   const arbitrumVotes = arbitrumVotersResponse.arbitrumPoll.votes;
 
   const isVoteWithinPollTimeframe = vote => vote.blockTime >= startUnix && vote.blockTime <= endUnix;
+  const getVoterAddress = (voter: VoterData | VoterWithWeight) =>
+    voter.address || stripChainIdPrefix(voter.id);
   const mapToDelegateAddress = (voterAddress: string) => delegateOwnerToAddress[voterAddress] || voterAddress;
 
   // Normalize voters to the delegate contract address used for dedupe and weight lookup.
   const mainnetVoterAddresses = mainnetVotes
     .filter(isVoteWithinPollTimeframe)
-    .map(vote => vote.voter.address);
+    .map(vote => getVoterAddress(vote.voter));
   const arbitrumVoterAddresses = arbitrumVotes
     .filter(isVoteWithinPollTimeframe)
-    .map(vote => mapToDelegateAddress(vote.voter.address));
+    .map(vote => mapToDelegateAddress(getVoterAddress(vote.voter)));
 
   const allVoterAddresses = [...mainnetVoterAddresses, ...arbitrumVoterAddresses];
 
-  const normalizeVoteVoterAddress = (vote, chainId, voterAddress = vote.voter.address) => ({
+  const normalizeVoteVoterAddress = (vote, chainId, voterAddress = getVoterAddress(vote.voter)) => ({
     ...vote,
     chainId,
     voter: { ...vote.voter, id: voterAddress, address: voterAddress }
@@ -114,7 +117,7 @@ export async function fetchVotesByAddressForPoll(
   );
 
   const arbitrumVotesTaggedWithChainId = arbitrumVotes.map(vote => {
-    const mappedAddress = mapToDelegateAddress(vote.voter.address);
+    const mappedAddress = mapToDelegateAddress(getVoterAddress(vote.voter));
     return normalizeVoteVoterAddress(vote, arbitrumChainId, mappedAddress);
   });
 
@@ -138,7 +141,7 @@ export async function fetchVotesByAddressForPoll(
 
   const votesWithWeights = dedupedVotes.map((vote: (typeof allVotes)[0]) => {
     const voterId = vote.voter.address;
-    const voterData = votersWithWeights.find(voter => voter.address === voterId);
+    const voterData = votersWithWeights.find(voter => getVoterAddress(voter) === voterId);
     const votingPowerChanges = voterData?.v2VotingPowerChanges || [];
     const skySupport = votingPowerChanges.length > 0 ? votingPowerChanges[0].newBalance : '0';
 

--- a/modules/polling/api/fetchVotesByAddress.ts
+++ b/modules/polling/api/fetchVotesByAddress.ts
@@ -93,7 +93,7 @@ export async function fetchVotesByAddressForPoll(
   const isVoteWithinPollTimeframe = vote => vote.blockTime >= startUnix && vote.blockTime <= endUnix;
   const mapToDelegateAddress = (voterAddress: string) => delegateOwnerToAddress[voterAddress] || voterAddress;
 
-  // Strip chainId prefix from voter IDs to get plain addresses
+  // Normalize voters to the delegate contract address used for dedupe and weight lookup.
   const mainnetVoterAddresses = mainnetVotes
     .filter(isVoteWithinPollTimeframe)
     .map(vote => vote.voter.address);
@@ -103,25 +103,25 @@ export async function fetchVotesByAddressForPoll(
 
   const allVoterAddresses = [...mainnetVoterAddresses, ...arbitrumVoterAddresses];
 
-  const addChainIdToVote = (vote, chainId) => ({ ...vote, chainId });
+  const normalizeVoteVoterAddress = (vote, chainId, voterAddress = vote.voter.address) => ({
+    ...vote,
+    chainId,
+    voter: { ...vote.voter, id: voterAddress, address: voterAddress }
+  });
 
   const mainnetVotesWithChainId = mainnetVotes.map(vote =>
-    addChainIdToVote(vote, mainnetChainId)
+    normalizeVoteVoterAddress(vote, mainnetChainId)
   );
 
   const arbitrumVotesTaggedWithChainId = arbitrumVotes.map(vote => {
     const mappedAddress = mapToDelegateAddress(vote.voter.address);
-    return {
-      ...vote,
-      chainId: arbitrumChainId,
-      voter: { ...vote.voter, id: mappedAddress }
-    };
+    return normalizeVoteVoterAddress(vote, arbitrumChainId, mappedAddress);
   });
 
   const allVotes = [...mainnetVotesWithChainId, ...arbitrumVotesTaggedWithChainId];
   const dedupedVotes = Object.values(
     allVotes.reduce((acc, vote) => {
-      const voterAddr = vote.voter.address || vote.voter.id;
+      const voterAddr = vote.voter.address;
       if (!acc[voterAddr] || Number(vote.blockTime) > Number(acc[voterAddr].blockTime)) {
         acc[voterAddr] = vote;
       }
@@ -137,7 +137,7 @@ export async function fetchVotesByAddressForPoll(
   const votersWithWeights = skyWeightsResponse.voters || [];
 
   const votesWithWeights = dedupedVotes.map((vote: (typeof allVotes)[0]) => {
-    const voterId = vote.voter.address || vote.voter.id;
+    const voterId = vote.voter.address;
     const voterData = votersWithWeights.find(voter => voter.address === voterId);
     const votingPowerChanges = voterData?.v2VotingPowerChanges || [];
     const skySupport = votingPowerChanges.length > 0 ? votingPowerChanges[0].newBalance : '0';


### PR DESCRIPTION
## Summary

This fixes three correctness regressions introduced by the Envio aggregate migration:

- Gasless poll votes are now deduped and weighted by the mapped delegate address  
- Per-delegate SKY and delegator totals no longer include staking-engine rows  
- Delegation summary metrics once again exclude staking-engine rows  

## Changes

- Normalize poll voter addresses before dedupe and voting-power lookup so gasless Arbitrum votes collapse correctly with the delegate's mainnet vote  
- Restore filtered delegation data on delegate list queries and use it to compute displayed `skyDelegated`  
- Detect staking-engine delegation separately so `delegatorCount` can subtract the special row without relying on the truncated delegations relation length  
- Reintroduce a paginated Delegation query for summary metrics with staking-engine addresses excluded  
- Add regression tests for:
  - Mapped gasless vote dedupe and weight preservation  
  - Delegation metrics pagination with staking-engine exclusion  
