### PR TITLE
Increase minimum release age to 7 days and add axios version overrides

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 script-shell = bash
-minimum-release-age=1440
+minimum-release-age=10080

--- a/package.json
+++ b/package.json
@@ -112,5 +112,11 @@
   "resolutions": {
     "elliptic": "^6.6.1"
   },
+  "pnpm": {
+    "overrides": {
+      "axios@1.14.1": "1.13.2",
+      "axios@0.30.4": "0.21.4"
+    }
+  },
   "packageManager": "pnpm@10.17.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   elliptic: ^6.6.1
+  axios@1.14.1: 1.13.2
+  axios@0.30.4: 0.21.4
 
 importers:
 
@@ -2587,8 +2589,8 @@ packages:
   axios@0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
 
-  axios@1.12.2:
-    resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
+  axios@1.13.2:
+    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
 
   axobject-query@3.2.1:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
@@ -8713,7 +8715,7 @@ snapshots:
       '@swagger-api/apidom-core': 1.0.0-beta.51
       '@swagger-api/apidom-error': 1.0.0-beta.51
       '@types/ramda': 0.30.2
-      axios: 1.12.2(debug@4.4.0)
+      axios: 1.13.2(debug@4.4.0)
       minimatch: 7.4.6
       process: 0.11.10
       ramda: 0.30.1
@@ -9962,7 +9964,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.12.2(debug@4.4.0):
+  axios@1.13.2(debug@4.4.0):
     dependencies:
       follow-redirects: 1.15.6(debug@4.4.0)
       form-data: 4.0.4


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                       
  - Bumps `minimum-release-age` from 1440 (24h) to 10080 (7 days) in `.npmrc` to mitigate supply chain attacks from newly published malicious packages                                                             
  - Adds pnpm overrides to pin compromised axios versions (`1.14.1` → `1.13.2`, `0.30.4` → `0.21.4`) as a precaution against the recent axios supply chain attack 