### PR TITLE
Security: Wave 1 — patch critical axios & protobufjs CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,8 +114,9 @@
   },
   "pnpm": {
     "overrides": {
-      "axios@1.14.1": "1.13.2",
-      "axios@0.30.4": "0.21.4"
+      "axios@^1": "1.15.0",
+      "protobufjs@^6": "7.5.5",
+      "protobufjs@^7": "7.5.5"
     }
   },
   "packageManager": "pnpm@10.17.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,9 @@ settings:
 
 overrides:
   elliptic: ^6.6.1
-  axios@1.14.1: 1.13.2
-  axios@0.30.4: 0.21.4
+  axios@^1: 1.15.0
+  protobufjs@^6: 7.5.5
+  protobufjs@^7: 7.5.5
 
 importers:
 
@@ -1995,9 +1996,6 @@ packages:
   '@types/lodash@4.17.0':
     resolution: {integrity: sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==}
 
-  '@types/long@4.0.2':
-    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
-
   '@types/mdast@3.0.15':
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
 
@@ -2589,8 +2587,8 @@ packages:
   axios@0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
 
-  axios@1.13.2:
-    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   axobject-query@3.2.1:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
@@ -3681,6 +3679,15 @@ packages:
       debug:
         optional: true
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
 
@@ -3692,8 +3699,8 @@ packages:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -4473,8 +4480,8 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
-  long@4.0.0:
-    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -5228,15 +5235,16 @@ packages:
   property-information@6.5.0:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
 
-  protobufjs@6.11.4:
-    resolution: {integrity: sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==}
-    hasBin: true
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
+    engines: {node: '>=12.0.0'}
 
   proxy-compare@2.5.1:
     resolution: {integrity: sha512-oyfc0Tx87Cpwva5ZXezSp5V9vht1c7dZBhvuV/y3ctkgMVUmiAGDVeeB0dKhGSyT0v1ZTEQYpe/RXlBVBNuCLA==}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
@@ -8715,7 +8723,7 @@ snapshots:
       '@swagger-api/apidom-core': 1.0.0-beta.51
       '@swagger-api/apidom-error': 1.0.0-beta.51
       '@types/ramda': 0.30.2
-      axios: 1.13.2(debug@4.4.0)
+      axios: 1.15.0(debug@4.4.0)
       minimatch: 7.4.6
       process: 0.11.10
       ramda: 0.30.1
@@ -8996,8 +9004,6 @@ snapshots:
   '@types/json5@0.0.29': {}
 
   '@types/lodash@4.17.0': {}
-
-  '@types/long@4.0.2': {}
 
   '@types/mdast@3.0.15':
     dependencies:
@@ -9964,11 +9970,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.13.2(debug@4.4.0):
+  axios@1.15.0(debug@4.4.0):
     dependencies:
-      follow-redirects: 1.15.6(debug@4.4.0)
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
+      follow-redirects: 1.16.0(debug@4.4.0)
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -11292,6 +11298,10 @@ snapshots:
     optionalDependencies:
       debug: 4.4.0
 
+  follow-redirects@1.16.0(debug@4.4.0):
+    optionalDependencies:
+      debug: 4.4.0
+
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
@@ -11305,7 +11315,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  form-data@4.0.4:
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -11732,7 +11742,7 @@ snapshots:
   ipfs-unixfs@4.0.3:
     dependencies:
       err-code: 3.0.1
-      protobufjs: 6.11.4
+      protobufjs: 7.5.5
 
   ipld-dag-pb@0.22.3:
     dependencies:
@@ -11740,7 +11750,7 @@ snapshots:
       interface-ipld-format: 1.0.1
       multicodec: 3.2.1
       multihashing-async: 2.1.4
-      protobufjs: 6.11.4
+      protobufjs: 7.5.5
       stable: 0.1.8
       uint8arrays: 2.1.10
 
@@ -12174,7 +12184,7 @@ snapshots:
 
   lodash@4.17.21: {}
 
-  long@4.0.0: {}
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -13094,7 +13104,7 @@ snapshots:
 
   property-information@6.5.0: {}
 
-  protobufjs@6.11.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -13106,13 +13116,12 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/long': 4.0.2
       '@types/node': 20.19.23
-      long: 4.0.0
+      long: 5.3.2
 
   proxy-compare@2.5.1: {}
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   pump@3.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Wave 1 of a staged dependency-security cleanup addressing the open Dependabot alerts (currently 1 critical / 39 high / 48 moderate / 9 low).

This PR replaces the existing stale `pnpm.overrides` with entries that force patched versions of two transitive dependencies responsible for the critical and several high-severity alerts:

- `axios@^1` → `1.15.0` — clears the **two critical** alerts (#127, #129, cloud-metadata exfiltration via header injection) plus 3 high + 5 medium (NO_PROXY SSRF, `__proto__` DoS in mergeConfig, absolute-URL SSRF). The 1.x chain enters the repo via `swagger-ui-react → swagger-client → @swagger-api/apidom-reference`.
- `protobufjs@^6` / `^7` → `7.5.5` — clears the **critical** RCE alert (#131). The chain enters via `ipfs-only-hash → ipfs-unixfs-importer → {ipfs-unixfs, ipld-dag-pb}`.

The previous overrides (`axios@1.14.1 → 1.13.2`, `axios@0.30.4 → 0.21.4`) no longer matched anything in the resolved tree and left the vulnerable versions in place.

Verified resolution:
```
swagger-ui-react 5.29.5 → ... → axios 1.15.0
ipfs-only-hash 4.0.0 → ... → protobufjs 7.5.5
```

## Explicitly deferred (to be handled in follow-up PRs)

- **axios 0.21.4 via `defender-relay-client`**: the package is deprecated and will be migrated to `@openzeppelin/defender-sdk-relay-signer-client`. Jumping 0.21 → 0.31/1.x without that migration risks breaking transaction relaying.
- **Next.js 14.x CVEs (~10 alerts)**: no patch exists for the 14.x line — all advisories require 15.5.x+. That is a major-version migration (Pages Router, caching semantics) and warrants its own PR.
- **Wave 2 transitive bundle** (`node-forge`, `minimatch`, `h3`, `defu`, `cross-spawn`, `ws`, `serialize-javascript`, `socket.io-parser`, `picomatch`, `preact`, `validator`, `immutable`).
- **Wave 3 dev-deps** (`happy-dom`, `vite`, `rollup`, `flatted`, `glob`, `esbuild`).
- **Wave 4 cleanup** (`dompurify ≥ 3.4.0` override for 9 medium alerts, plus the unfixed-upstream `lodash._template` alert — requires a usage audit).

## Test plan

- [x] `pnpm install` resolves cleanly (pre-existing React peer warnings unrelated to this change)
- [x] `pnpm build` succeeds (all routes produce output)
- [x] `pnpm test` — 178 tests across 36 files pass
- [ ] Smoke-test swagger/openapi doc rendering in dev (`/api/doc`) — depends on the new axios 1.15.0
- [ ] Smoke-test IPFS hash computation code path — depends on the new protobufjs 7.5.5
- [ ] `pnpm e2e` in CI