### PR TITLE
Combined dependabot updates: lodash, vite, brace-expansion (#90, #91, #93)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "gray-matter": "^4.0.2",
     "ioredis": "^5.0.6",
     "ipfs-only-hash": "^4.0.0",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "lottie-web": "^5.7.1",
     "mersenne-twister": "^1.1.0",
     "next": "^15.5.18",
@@ -132,7 +132,9 @@
       "@metamask/sdk": "^0.33.1",
       "@metamask/sdk-communication-layer": "^0.33.1",
       "serialize-javascript": "^7.0.5",
-      "postcss@>=8 <9": "^8.5.10"
+      "postcss@>=8 <9": "^8.5.10",
+      "vite@>=6 <7": "^6.4.2",
+      "brace-expansion@>=1 <2": "^1.1.14"
     }
   },
   "packageManager": "pnpm@10.17.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,8 @@ overrides:
   '@metamask/sdk-communication-layer': ^0.33.1
   serialize-javascript: ^7.0.5
   postcss@>=8 <9: ^8.5.10
+  vite@>=6 <7: ^6.4.2
+  brace-expansion@>=1 <2: ^1.1.14
 
 importers:
 
@@ -98,8 +100,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       lodash:
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^4.18.1
+        version: 4.18.1
       lottie-web:
         specifier: ^5.7.1
         version: 5.12.2
@@ -217,7 +219,7 @@ importers:
         version: 8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.2.5(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0))
+        version: 4.3.4(vite@6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0))
       '@vitest/coverage-v8':
         specifier: ^3.0.9
         version: 3.0.9(vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.17.23)(happy-dom@20.0.2)(jiti@1.21.0)(terser@5.31.0))
@@ -277,7 +279,7 @@ importers:
         version: 5.8.2
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.2)(vite@6.2.5(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0))
+        version: 5.1.4(typescript@5.8.2)(vite@6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0))
       vitest:
         specifier: ^3.0.9
         version: 3.0.9(@types/debug@4.1.12)(@types/node@20.17.23)(happy-dom@20.0.2)(jiti@1.21.0)(terser@5.31.0)
@@ -2263,7 +2265,7 @@ packages:
     resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0
+      vite: ^6.4.2
 
   '@vitest/coverage-v8@3.0.9':
     resolution: {integrity: sha512-15OACZcBtQ34keIEn19JYTVuMFTlFrClclwWjHo/IRPg/8ELpkgNTl0o7WLP9WO9XGH6+tip9CPYtEOrIDJvBA==}
@@ -2281,7 +2283,7 @@ packages:
     resolution: {integrity: sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0
+      vite: ^6.4.2
     peerDependenciesMeta:
       msw:
         optional: true
@@ -4639,8 +4641,8 @@ packages:
   lodash.mergewith@4.6.2:
     resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -5316,6 +5318,10 @@ packages:
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
+
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
@@ -6600,13 +6606,13 @@ packages:
   vite-tsconfig-paths@5.1.4:
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
     peerDependencies:
-      vite: '*'
+      vite: ^6.4.2
     peerDependenciesMeta:
       vite:
         optional: true
 
-  vite@6.2.5:
-    resolution: {integrity: sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==}
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -9086,7 +9092,7 @@ snapshots:
       chalk: 3.0.0
       css.escape: 1.5.1
       dom-accessibility-api: 0.5.16
-      lodash: 4.17.23
+      lodash: 4.18.1
       redent: 3.0.0
 
   '@testing-library/react@16.2.0(@testing-library/dom@10.4.0)(@types/react@18.3.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -9463,14 +9469,14 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@vitejs/plugin-react@4.3.4(vite@6.2.5(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0))':
+  '@vitejs/plugin-react@4.3.4(vite@6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.5(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0)
+      vite: 6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9499,13 +9505,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.9(vite@6.2.5(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0))':
+  '@vitest/mocker@3.0.9(vite@6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0))':
     dependencies:
       '@vitest/spy': 3.0.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.5(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0)
+      vite: 6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0)
 
   '@vitest/pretty-format@3.0.9':
     dependencies:
@@ -10801,7 +10807,7 @@ snapshots:
       amazon-cognito-identity-js: 6.3.12
       async-retry: 1.3.3
       axios: 0.31.1(debug@4.4.0)
-      lodash: 4.17.23
+      lodash: 4.18.1
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - debug
@@ -10817,7 +10823,7 @@ snapshots:
       amazon-cognito-identity-js: 6.3.12
       axios: 0.31.1(debug@4.4.0)
       defender-base-client: 1.44.0(debug@4.4.0)
-      lodash: 4.17.23
+      lodash: 4.18.1
       node-fetch: 2.7.0
       web3-core: 1.10.4
       web3-core-helpers: 1.10.4
@@ -12560,7 +12566,7 @@ snapshots:
 
   lodash.mergewith@4.6.2: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   long@5.3.2: {}
 
@@ -12963,7 +12969,7 @@ snapshots:
 
   minim@0.23.8:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
 
   minimalistic-assert@1.0.1: {}
 
@@ -13407,6 +13413,12 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
+  postcss@8.5.13:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
@@ -13637,7 +13649,7 @@ snapshots:
 
   react-resize-detector@8.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -13730,7 +13742,7 @@ snapshots:
     dependencies:
       classnames: 2.5.1
       eventemitter3: 4.0.7
-      lodash: 4.17.23
+      lodash: 4.18.1
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -14395,7 +14407,7 @@ snapshots:
       immutable: 3.8.3
       js-file-download: 0.4.12
       js-yaml: 4.1.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       prop-types: 15.8.1
       randexp: 0.5.3
       randombytes: 2.1.0
@@ -14899,10 +14911,10 @@ snapshots:
   vite-node@3.0.9(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0
+      debug: 4.4.3
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.5(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0)
+      vite: 6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14917,22 +14929,25 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.2.5(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.8.2)
     optionalDependencies:
-      vite: 6.2.5(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0)
+      vite: 6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.2.5(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0):
+  vite@6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0):
     dependencies:
       esbuild: 0.25.1
-      postcss: 8.5.14
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.13
       rollup: 4.36.0
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 20.17.23
       fsevents: 2.3.3
@@ -14942,7 +14957,7 @@ snapshots:
   vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.17.23)(happy-dom@20.0.2)(jiti@1.21.0)(terser@5.31.0):
     dependencies:
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(vite@6.2.5(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0))
+      '@vitest/mocker': 3.0.9(vite@6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0))
       '@vitest/pretty-format': 3.0.9
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9
@@ -14958,7 +14973,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.5(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0)
+      vite: 6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0)
       vite-node: 3.0.9(@types/node@20.17.23)(jiti@1.21.0)(terser@5.31.0)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## Summary

Combines Dependabot PRs #90, #91, and #93 into a single PR branched off latest `development`.

- **lodash** `4.17.23` → `4.18.1` (#91) — direct dependency, bumped in `package.json`
- **vite** `6.2.5` → `6.4.2` (#93) — indirect dependency, pinned via `pnpm.overrides` (`vite@>=6 <7` → `^6.4.2`)
- **brace-expansion** `1.1.11` → `1.1.14` (#90) — indirect dependency, pinned via `pnpm.overrides` (`brace-expansion@>=1 <2` → `^1.1.14`)

Lockfile regenerated with `pnpm install`.

Closes #90
Closes #91
Closes #93

## Test plan

- [ ] CI passes on `feature/combined-dependabot-90-91-93`
- [ ] `pnpm install` runs cleanly
- [ ] `pnpm test` passes
- [ ] `pnpm build` passes
- [ ] Verify resolved versions in `pnpm-lock.yaml`: `lodash@4.18.1`, `vite@6.4.2`, `brace-expansion@1.1.14`