### PR TITLE
Fix executive/polling 404s by renaming dynamic route segments (APP-244)

### DIFF
--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -19,6 +19,7 @@ import { getExecutiveProposalsCacheKey, githubExecutivesCacheKey } from 'modules
 import { ONE_HOUR_IN_MS } from 'modules/app/constants/time';
 import { trimProposalKey } from '../helpers/trimProposalKey';
 import { matterWrapper } from 'lib/matter';
+import { isAddress } from 'viem';
 
 export async function getGithubExecutives(network: SupportedNetworks): Promise<CMSProposal[]> {
   const cachedProposals = await cacheGet(githubExecutivesCacheKey, network);
@@ -202,7 +203,30 @@ export async function getExecutiveProposal(
       proposal.key === proposalId ||
       proposal.address.toLowerCase() === proposalId.toLowerCase()
   );
-  if (!proposal) return null;
+
+  if (!proposal) {
+    // Fall back to on-chain spell data when the id is a valid address that
+    // isn't in the github executive-votes index. Without this, deep links to
+    // older or unindexed spells return 404 (APP-244). We only render when
+    // description() returned an executive hash, which confirms the address is
+    // an actual DSS spell rather than an arbitrary EOA.
+    if (isAddress(proposalId, { strict: false })) {
+      const spellData = await analyzeSpell(proposalId, currentNetwork);
+      if (spellData.executiveHash) {
+        return {
+          active: false,
+          address: proposalId,
+          key: proposalId.toLowerCase(),
+          proposalBlurb: '',
+          title: '',
+          date: '',
+          proposalLink: '',
+          spellData
+        };
+      }
+    }
+    return null;
+  }
   invariant(proposal, `proposal not found for proposal id ${proposalId}`);
 
   const [spellText, spellData] = await Promise.all([

--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { DEFAULT_NETWORK, SupportedNetworks } from 'modules/web3/constants/networks';
 import { cacheGet, cacheSet } from 'modules/cache/cache';
-import { CMSProposal, Proposal, GithubProposal } from 'modules/executive/types';
+import { CMSProposal, Proposal, GithubProposal, SpellData } from 'modules/executive/types';
 import { parseExecutive } from './parseExecutive';
 import invariant from 'tiny-invariant';
 import { markdownToHtml } from 'lib/markdown';
@@ -205,35 +205,35 @@ export async function getExecutiveProposal(
   );
 
   if (!proposal) {
-    // Fall back to on-chain spell data when the id is a valid address that
-    // isn't in the github executive-votes index. Without this, deep links to
-    // older or unindexed spells return 404 (APP-244). We only render when
-    // description() returned an executive hash, which confirms the address is
-    // an actual DSS spell rather than an arbitrary EOA.
+    // Fall back to rendering a minimal page when the id is a valid address
+    // that isn't in the github executive-votes index. Without this, deep links
+    // to older or unindexed spells return 404 (APP-244). We attempt to enrich
+    // with on-chain spell data via analyzeSpell, but render even if that fails
+    // — matches the /custom-spell/[address] behavior and avoids 404s when the
+    // RPC proxy is unreachable (e.g. from some preview environments).
     if (isAddress(proposalId, { strict: false })) {
+      let spellData: SpellData = {
+        hasBeenScheduled: false,
+        skySupport: '0'
+      };
       try {
-        const spellData = await analyzeSpell(proposalId, currentNetwork);
-        if (spellData.executiveHash) {
-          return {
-            active: false,
-            address: proposalId,
-            key: proposalId.toLowerCase(),
-            proposalBlurb: '',
-            title: '',
-            date: '',
-            proposalLink: '',
-            spellData
-          };
-        }
-        logger.warn(
-          `getExecutiveProposal: ${proposalId} not in github index and description() returned no executive hash on ${currentNetwork} — treating as not-a-spell`
-        );
+        spellData = await analyzeSpell(proposalId, currentNetwork);
       } catch (e) {
         logger.error(
-          `getExecutiveProposal: on-chain fallback failed for ${proposalId} on ${currentNetwork}`,
+          `getExecutiveProposal: analyzeSpell threw for ${proposalId} on ${currentNetwork}, rendering page without on-chain data`,
           e
         );
       }
+      return {
+        active: false,
+        address: proposalId,
+        key: proposalId.toLowerCase(),
+        proposalBlurb: '',
+        title: '',
+        date: '',
+        proposalLink: '',
+        spellData
+      };
     }
     return null;
   }

--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -211,18 +211,28 @@ export async function getExecutiveProposal(
     // description() returned an executive hash, which confirms the address is
     // an actual DSS spell rather than an arbitrary EOA.
     if (isAddress(proposalId, { strict: false })) {
-      const spellData = await analyzeSpell(proposalId, currentNetwork);
-      if (spellData.executiveHash) {
-        return {
-          active: false,
-          address: proposalId,
-          key: proposalId.toLowerCase(),
-          proposalBlurb: '',
-          title: '',
-          date: '',
-          proposalLink: '',
-          spellData
-        };
+      try {
+        const spellData = await analyzeSpell(proposalId, currentNetwork);
+        if (spellData.executiveHash) {
+          return {
+            active: false,
+            address: proposalId,
+            key: proposalId.toLowerCase(),
+            proposalBlurb: '',
+            title: '',
+            date: '',
+            proposalLink: '',
+            spellData
+          };
+        }
+        logger.warn(
+          `getExecutiveProposal: ${proposalId} not in github index and description() returned no executive hash on ${currentNetwork} — treating as not-a-spell`
+        );
+      } catch (e) {
+        logger.error(
+          `getExecutiveProposal: on-chain fallback failed for ${proposalId} on ${currentNetwork}`,
+          e
+        );
       }
     }
     return null;

--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -195,15 +195,7 @@ export async function getExecutiveProposal(
 
   const currentNetwork = net;
 
-  // APP-244 TRACE: remove after debugging
-  logger.info(`[APP-244] getExecutiveProposal start id=${proposalId} network=${currentNetwork}`);
-
   const proposals = await getGithubExecutives(currentNetwork);
-
-  // APP-244 TRACE
-  logger.info(
-    `[APP-244] getExecutiveProposal loaded ${proposals.length} proposals from github cache/fetch`
-  );
 
   const proposal = proposals.find(
     proposal =>
@@ -212,56 +204,36 @@ export async function getExecutiveProposal(
       proposal.address.toLowerCase() === proposalId.toLowerCase()
   );
 
-  // APP-244 TRACE
-  logger.info(
-    `[APP-244] getExecutiveProposal find result: ${proposal ? `found address=${proposal.address}` : 'NOT FOUND in github index'}`
-  );
-
   if (!proposal) {
-    // Fall back to rendering a minimal page when the id is a valid address
-    // that isn't in the github executive-votes index. Without this, deep links
-    // to older or unindexed spells return 404 (APP-244). We attempt to enrich
-    // with on-chain spell data via analyzeSpell, but render even if that fails
-    // — matches the /custom-spell/[address] behavior and avoids 404s when the
-    // RPC proxy is unreachable (e.g. from some preview environments).
+    // Fall back to on-chain spell data when the id is a valid address that
+    // isn't in the github executive-votes index. Without this, deep links to
+    // older or unindexed spells return 404 (APP-244). We only render when
+    // description() returns an executive hash, confirming the address is an
+    // actual DSS spell rather than an arbitrary EOA.
     if (isAddress(proposalId, { strict: false })) {
-      // APP-244 TRACE
-      logger.info(`[APP-244] entering on-chain fallback for ${proposalId}`);
-      let spellData: SpellData = {
-        hasBeenScheduled: false,
-        skySupport: '0'
-      };
       try {
-        spellData = await analyzeSpell(proposalId, currentNetwork);
-        // APP-244 TRACE
-        logger.info(
-          `[APP-244] analyzeSpell returned executiveHash=${spellData.executiveHash ?? 'undefined'}`
-        );
+        const spellData = await analyzeSpell(proposalId, currentNetwork);
+        if (spellData.executiveHash) {
+          return {
+            active: false,
+            address: proposalId,
+            key: proposalId.toLowerCase(),
+            proposalBlurb: '',
+            title: '',
+            date: '',
+            proposalLink: '',
+            spellData
+          };
+        }
       } catch (e) {
         logger.error(
-          `[APP-244] analyzeSpell threw for ${proposalId} on ${currentNetwork}, rendering page without on-chain data`,
+          `getExecutiveProposal: analyzeSpell threw for ${proposalId} on ${currentNetwork}`,
           e
         );
       }
-      // APP-244 TRACE
-      logger.info(`[APP-244] fallback returning Proposal with key=${proposalId.toLowerCase()}`);
-      return {
-        active: false,
-        address: proposalId,
-        key: proposalId.toLowerCase(),
-        proposalBlurb: '',
-        title: '',
-        date: '',
-        proposalLink: '',
-        spellData
-      };
     }
-    // APP-244 TRACE
-    logger.warn(`[APP-244] not a valid address — returning null for id=${proposalId}`);
     return null;
   }
-  // APP-244 TRACE
-  logger.info(`[APP-244] github match for ${proposalId}, fetching content + analyzeSpell`);
   invariant(proposal, `proposal not found for proposal id ${proposalId}`);
 
   const [spellText, spellData] = await Promise.all([

--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -195,13 +195,26 @@ export async function getExecutiveProposal(
 
   const currentNetwork = net;
 
+  // APP-244 TRACE: remove after debugging
+  logger.info(`[APP-244] getExecutiveProposal start id=${proposalId} network=${currentNetwork}`);
+
   const proposals = await getGithubExecutives(currentNetwork);
+
+  // APP-244 TRACE
+  logger.info(
+    `[APP-244] getExecutiveProposal loaded ${proposals.length} proposals from github cache/fetch`
+  );
 
   const proposal = proposals.find(
     proposal =>
       trimProposalKey(proposal.key) === proposalId ||
       proposal.key === proposalId ||
       proposal.address.toLowerCase() === proposalId.toLowerCase()
+  );
+
+  // APP-244 TRACE
+  logger.info(
+    `[APP-244] getExecutiveProposal find result: ${proposal ? `found address=${proposal.address}` : 'NOT FOUND in github index'}`
   );
 
   if (!proposal) {
@@ -212,18 +225,26 @@ export async function getExecutiveProposal(
     // — matches the /custom-spell/[address] behavior and avoids 404s when the
     // RPC proxy is unreachable (e.g. from some preview environments).
     if (isAddress(proposalId, { strict: false })) {
+      // APP-244 TRACE
+      logger.info(`[APP-244] entering on-chain fallback for ${proposalId}`);
       let spellData: SpellData = {
         hasBeenScheduled: false,
         skySupport: '0'
       };
       try {
         spellData = await analyzeSpell(proposalId, currentNetwork);
+        // APP-244 TRACE
+        logger.info(
+          `[APP-244] analyzeSpell returned executiveHash=${spellData.executiveHash ?? 'undefined'}`
+        );
       } catch (e) {
         logger.error(
-          `getExecutiveProposal: analyzeSpell threw for ${proposalId} on ${currentNetwork}, rendering page without on-chain data`,
+          `[APP-244] analyzeSpell threw for ${proposalId} on ${currentNetwork}, rendering page without on-chain data`,
           e
         );
       }
+      // APP-244 TRACE
+      logger.info(`[APP-244] fallback returning Proposal with key=${proposalId.toLowerCase()}`);
       return {
         active: false,
         address: proposalId,
@@ -235,8 +256,12 @@ export async function getExecutiveProposal(
         spellData
       };
     }
+    // APP-244 TRACE
+    logger.warn(`[APP-244] not a valid address — returning null for id=${proposalId}`);
     return null;
   }
+  // APP-244 TRACE
+  logger.info(`[APP-244] github match for ${proposalId}, fetching content + analyzeSpell`);
   invariant(proposal, `proposal not found for proposal id ${proposalId}`);
 
   const [spellText, spellData] = await Promise.all([

--- a/pages/api/executive/[proposalId].ts
+++ b/pages/api/executive/[proposalId].ts
@@ -180,7 +180,7 @@ export default withApiHandler(
 
     // Validate proposal-id format (kebab-case string or ethereum address)
     const proposalId = validateQueryParam(
-      req.query['proposal-id'] as string,
+      req.query.proposalId as string,
       'string',
       { defaultValue: null },
       (id: string) => {

--- a/pages/api/polling/[pollIdOrSlug].ts
+++ b/pages/api/polling/[pollIdOrSlug].ts
@@ -220,14 +220,14 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse<P
     validValues: [SupportedNetworks.TENDERLY, SupportedNetworks.MAINNET]
   }) as SupportedNetworks;
 
-  const pollId = validateQueryParam(req.query['poll-id-or-slug'], 'number', {
+  const pollId = validateQueryParam(req.query.pollIdOrSlug, 'number', {
     defaultValue: null
   }) as number | null;
 
   let pollSlug: string | null = null;
 
   if (!pollId) {
-    pollSlug = validateQueryParam(req.query['poll-id-or-slug'], 'string', {
+    pollSlug = validateQueryParam(req.query.pollIdOrSlug, 'string', {
       defaultValue: null
     }) as string | null;
   }

--- a/pages/api/polling/tally/[pollId].ts
+++ b/pages/api/polling/tally/[pollId].ts
@@ -253,7 +253,7 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
 
   // validate pollId
   const pollId = validateQueryParam(
-    req.query['poll-id'],
+    req.query.pollId,
     'number',
     {
       defaultValue: null,

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -492,7 +492,21 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   // fetch proposal contents at build-time if on the default network
   const proposalId = (params || {})['proposal-id'] as string;
 
+  // APP-244 TRACE: remove after debugging
+  // eslint-disable-next-line no-console
+  console.log(`[APP-244] getStaticProps start id=${proposalId}`);
+
   const proposal: Proposal | null = await getExecutiveProposal(proposalId, DEFAULT_NETWORK.network);
+
+  // APP-244 TRACE
+  // eslint-disable-next-line no-console
+  console.log(
+    `[APP-244] getStaticProps result for id=${proposalId}: ${
+      proposal
+        ? `proposal.key=${proposal.key} title=${(proposal.title || '').slice(0, 40)}`
+        : 'proposal=null (will render 404)'
+    }`
+  );
 
   /**Disabling spell-effects until multi-transactions endpoint is ready */
   // // Only fetch at build time if spell has been cast, and it's not older than two months (to speed up builds)

--- a/pages/executive/[proposalId].tsx
+++ b/pages/executive/[proposalId].tsx
@@ -492,36 +492,16 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   // fetch proposal contents at build-time if on the default network
   const proposalId = (params || {}).proposalId as string;
 
-  // APP-244 TRACE: remove after debugging
-  // eslint-disable-next-line no-console
-  console.log(`[APP-244] getStaticProps start id=${proposalId}`);
-
   const proposal: Proposal | null = await getExecutiveProposal(proposalId, DEFAULT_NETWORK.network);
 
-  // APP-244 TRACE
-  // eslint-disable-next-line no-console
-  console.log(
-    `[APP-244] getStaticProps result for id=${proposalId}: ${
-      proposal
-        ? `proposal.key=${proposal.key} title=${(proposal.title || '').slice(0, 40)}`
-        : 'proposal=null (will render 404)'
-    }`
-  );
-
-  /**Disabling spell-effects until multi-transactions endpoint is ready */
-  // // Only fetch at build time if spell has been cast, and it's not older than two months (to speed up builds)
-  // const spellDiffs: SpellDiff[] =
-  //   proposal &&
-  //   proposal.spellData?.hasBeenCast &&
-  //   isAfter(new Date(proposal?.date), sub(new Date(), { months: 2 }))
-  //     ? await fetchHistoricalSpellDiff(proposal.address)
-  //     : [];
+  if (!proposal) {
+    return { notFound: true, revalidate: 60 * 60 };
+  }
 
   return {
     revalidate: 60 * 60, // Revalidate each hour
     props: {
       proposal,
-      // spellDiffs,
       revalidate: 30 // Ensures that after a spell is cast, we regenerate the static page with fetchHistoricalSpellDiff
     }
   };

--- a/pages/executive/[proposalId].tsx
+++ b/pages/executive/[proposalId].tsx
@@ -447,14 +447,14 @@ export default function ProposalPage({
   // fetch proposal contents at run-time if on any network other than the default
   useEffect(() => {
     if (!network) return;
-    if (!isDefaultNetwork(network) && query['proposal-id']) {
-      fetchJson(`/api/executive/${query['proposal-id']}?network=${network}`)
+    if (!isDefaultNetwork(network) && query.proposalId) {
+      fetchJson(`/api/executive/${query.proposalId}?network=${network}`)
         .then(response => {
           _setProposal(response);
         })
         .catch(setError);
     }
-  }, [query['proposal-id'], network]);
+  }, [query.proposalId, network]);
 
   // Check for fallback state first
   if (router.isFallback) {
@@ -490,7 +490,7 @@ export default function ProposalPage({
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   // fetch proposal contents at build-time if on the default network
-  const proposalId = (params || {})['proposal-id'] as string;
+  const proposalId = (params || {}).proposalId as string;
 
   // APP-244 TRACE: remove after debugging
   // eslint-disable-next-line no-console

--- a/pages/polling/[pollHash].tsx
+++ b/pages/polling/[pollHash].tsx
@@ -404,14 +404,14 @@ export default function PollPage({ poll: prefetchedPoll }: { poll?: Poll }): JSX
   // fetch poll contents at run-time if on any network other than the default
   useEffect(() => {
     if (!network) return;
-    if (query['poll-hash'] && !isDefaultNetwork(network)) {
-      fetchJson(`/api/polling/${query['poll-hash']}?network=${network}`)
+    if (query.pollHash && !isDefaultNetwork(network)) {
+      fetchJson(`/api/polling/${query.pollHash}?network=${network}`)
         .then(response => {
           _setPoll(response);
         })
         .catch(setError);
     }
-  }, [query['poll-hash'], network]);
+  }, [query.pollHash, network]);
 
   const poll = (isDefaultNetwork(network) ? prefetchedPoll : _poll) as Poll;
 
@@ -442,7 +442,7 @@ export default function PollPage({ poll: prefetchedPoll }: { poll?: Poll }): JSX
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   // fetch poll contents at build-time if on the default network
-  const pollIdOrSlug = params?.['poll-hash'] as string;
+  const pollIdOrSlug = params?.pollHash as string;
   // invariant(pollSlug, 'getStaticProps poll hash not found in params');
 
   const poll = await fetchSinglePoll(DEFAULT_NETWORK.network, pollIdOrSlug);


### PR DESCRIPTION
### What does this PR do?

Fixes [APP-244](https://linear.app/skybasestar/issue/APP-244): deep-linking to an executive spell by address (e.g. `/executive/0xA0059…`) returned a 404 on Vercel preview/production deploys after the Next.js 14 → 15 upgrade. The same root cause affects `/polling/<hash>`, so this PR fixes both.

The same code worked correctly under `next start` locally on the exact same Next.js 15.5.18 build, which made the bug Vercel-specific.

#### Root cause

The dynamic route segments were named `[proposal-id]` and `[poll-hash]` etc. — kebab-case with hyphens. Hyphenated dynamic segment names in Next.js are **not officially supported**: see [vercel/next.js#41094](https://github.com/vercel/next.js/issues/41094), [discussion #41108](https://github.com/vercel/next.js/discussions/41108), and [#20928](https://github.com/vercel/next.js/discussions/20928) showing identical mangling behavior. They worked in earlier versions by happenstance.

Under Next.js 15 on Vercel's serverless runtime, page routes that go through `getStaticPaths` + `fallback: true` + ISR end up calling `getStaticProps` with `params['proposal-id'] === '[proposal-id]'` — the literal route template string, not the URL value. Confirmed with trace logs:

```
[APP-244] getStaticProps start id=[proposal-id]
[APP-244] getExecutiveProposal start id=[proposal-id] network=mainnet
[APP-244] getExecutiveProposal loaded 24 proposals from github cache/fetch
[APP-244] getExecutiveProposal find result: NOT FOUND in github index
[APP-244] not a valid address — returning null for id=[proposal-id]
[APP-244] getStaticProps result for id=[proposal-id]: proposal=null (will render 404)
```

The matching `/api/executive/[proposal-id]` handler was unaffected because API routes don't go through the static-generation/fallback pipeline — it was returning correct JSON the whole time.

#### The fix

Rename every hyphenated dynamic segment in `pages/` to camelCase:

| Before | After |
|---|---|
| `pages/executive/[proposal-id].tsx` | `pages/executive/[proposalId].tsx` |
| `pages/api/executive/[proposal-id].ts` | `pages/api/executive/[proposalId].ts` |
| `pages/polling/[poll-hash].tsx` | `pages/polling/[pollHash].tsx` |
| `pages/api/polling/[poll-id-or-slug].ts` | `pages/api/polling/[pollIdOrSlug].ts` |
| `pages/api/polling/tally/[poll-id].ts` | `pages/api/polling/tally/[pollId].ts` |

In-code param accesses updated to match (`params['proposal-id']` → `params.proposalId`, etc.). **The URL paths users hit are unchanged.** I audited the remaining dynamic segments — `[address]` and `[delegatorAddress]` are single-word/camelCase, no further renames needed.

#### Defensive changes also included

While diagnosing the bug I went down a few wrong-but-useful paths. Keeping them since each is independently a real resilience improvement for the executive page:

- `a182b661` Add on-chain fallback via `analyzeSpell()` so older / unindexed spells in the github executive-votes repo don't 404. Before commit `bd1cd925` (2025-04-11) `getGithubExecutives` walked the whole `makerdao/community` directory; after, it reads a 24-entry curated index. Anything outside that index used to 404 even with valid params.
- `deeb77e1` Wrap `analyzeSpell()` in try/catch so an RPC proxy failure doesn't propagate out of `getStaticProps`.
- `39b5b2b0` Return `notFound: true` from `getStaticProps` (proper HTTP 404 from Next.js `_error.tsx`) when the proposal is null, instead of passing `proposal: null` and letting the in-component `ErrorPage` render at HTTP 200.

The intermediate "always render for any valid 0x address" approach (`65e45df3`) was reverted in `39b5b2b0` once the rename made it unnecessary — it was producing misleading empty spell pages for random EOAs.

Diagnostic trace logs added in `b59b7139` have been stripped.

#### Steps for testing

`pnpm dev` (or `pnpm next build && pnpm start`):

| URL | Expected |
|---|---|
| `/executive/0xA0059DaDd7Fbdbc81a9bb9d1d17cCB029b6AF596` | Active hat — full Proposal Detail + Spell Details tabs |
| Same URL lowercased | Identical (case-insensitive address match) |
| `/executive/template-executive-vote-…` (slug form) | Identical |
| `/executive/0x1111111111111111111111111111111111111111` | Proper HTTP 404 ("Page not found") |
| `/executive/not-a-real-slug` | 404 |
| `/api/executive/0xA0059…` | 200 JSON |
| `/api/executive/0x1111…` | 404 JSON |
| `/polling/QmafyxBw` (poll 1626, fallback path) | Full poll detail — was 404'ing before this fix |
| `/polling/QmYeBemY` (pre-built) | Renders |
| `/polling/1626` (numeric id) | Renders |
| `/api/polling/QmafyxBw` | 200 JSON |
| `/api/polling/tally/1626` | 200 JSON |

All verified on the Vercel preview after `39b5b2b0`.

#### Follow-ups (out of scope for this PR)

- The Upstash Redis client (`REDIS_URL` on Vercel) is hitting "Reached the max retries per request limit (which is 20)" on essentially every call. The cache layer's `try/catch` swallows it but every cache read pays the full retry budget, slowing functions down meaningfully. Worth raising with whoever owns the Upstash setup.
- There's a separate latent 404 path if a visitor has a wallet connected to a non-mainnet, non-tenderly chain (e.g. Arbitrum): `pages/executive/[proposalId].tsx` runs a runtime fetch against `/api/executive/...?network=<chain>` and the API validator rejects anything other than mainnet/tenderly with a 400, which the page treats as an error and renders the in-component 404. Not part of APP-244; can be addressed in a follow-up.