### PR TITLE
Wave 4: dompurify ^3.4.0 override + lodash._template audit (APP-225)

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,8 @@
       "serialize-javascript": "^7.0.5",
       "postcss@>=8 <9": "^8.5.10",
       "vite@>=6 <7": "^6.4.2",
-      "brace-expansion@>=1 <2": "^1.1.14"
+      "brace-expansion@>=1 <2": "^1.1.14",
+      "dompurify": "^3.4.0"
     }
   },
   "packageManager": "pnpm@10.17.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ overrides:
   postcss@>=8 <9: ^8.5.10
   vite@>=6 <7: ^6.4.2
   brace-expansion@>=1 <2: ^1.1.14
+  dompurify: ^3.4.0
 
 importers:
 
@@ -3294,8 +3295,8 @@ packages:
   dom-helpers@3.4.0:
     resolution: {integrity: sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==}
 
-  dompurify@3.2.6:
-    resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
+  dompurify@3.4.2:
+    resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
 
   dotenv-expand@10.0.0:
     resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
@@ -10884,7 +10885,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.0
 
-  dompurify@3.2.6:
+  dompurify@3.4.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -14402,7 +14403,7 @@ snapshots:
       classnames: 2.5.1
       css.escape: 1.5.1
       deep-extend: 0.6.0
-      dompurify: 3.2.6
+      dompurify: 3.4.2
       ieee754: 1.2.1
       immutable: 3.8.3
       js-file-download: 0.4.12


### PR DESCRIPTION
## Summary

Final cleanup wave of the dependabot triage ([APP-225](https://linear.app/skybasestar/issue/APP-225), child of APP-221). Two surgical changes plus a documented watchlist.

- **dompurify override** → `^3.4.0` in `pnpm.overrides`. Lifts the transitive copy under `swagger-ui-react@5.29.5` from `3.2.6` to `3.4.2`. Closes 9 medium GHSAs (see list below).
- **lodash._template audit (#118)** → zero call sites in the repo. Recommend dismissing with justification rather than touching code.

### Alerts closed by the dompurify override

| Alert | GHSA | Path |
| -- | -- | -- |
| #135 | GHSA-h7mw-gpvr-xq4m | FORBID_TAGS bypass |
| #134 | GHSA-crv5-9vww-q3g8 | SAFE_FOR_TEMPLATES bypass in RETURN_DOM |
| #133 | GHSA-v9jr-rg53-9pgp | prototype pollution → XSS |
| #130 | GHSA-39q2-94rc-95cp | ADD_TAGS short-circuit |
| #112 | GHSA-cj63-jhhr-wcxv | USE_PROFILES prototype pollution |
| #111 | GHSA-cjmm-f4jc-qw8r | ADD_ATTR skips URI validation |
| #106 | GHSA-h8r8-wccr-v5f2 | mutation-XSS via re-contextualization |
| #84  | GHSA-v2wj-7wpq-c8vv | generic XSS |
| #83  | GHSA-v8jm-5vwx-cfxm | generic XSS |

Confirmed via `pnpm why dompurify`: only consumer is `swagger-ui-react`, now resolves to `dompurify@3.4.2`.

### `lodash._template` (#118 — GHSA-r5fr-rjxr-66jc)

Advisory's `first_patched_version` is `4.18.0`, which does not exist (lodash stable is 4.17.x), so this alert is unfixable upstream today. We do pin `lodash@^4.17.23` as a direct runtime dep, so the question is whether we actually use the affected API.

Audit run:

```
rg -n "_\.template\b|lodash/template|lodash\.template" -g '!node_modules' -g '!.next' -g '!playwright-report' -g '!test-results' .
```

→ **zero hits** across `pages/`, `modules/`, `lib/`, and elsewhere in the source tree. No `_.template` call sites exist. **Recommendation:** dismiss alert #118 on GitHub with justification \"no call sites — usage audited under APP-225\".

### Watchlist (no upstream fix — do not attempt)

Documenting current state so this doesn't get re-triaged:

- **`@stablelib/ed25519` 1.0.3 (#110)** — signature malleability; `first_patched_version: null`. Reachable via `wagmi → @wagmi/connectors → @walletconnect/* → @walletconnect/relay-auth`. No fix available.
- **`elliptic` 6.6.1 (#48)** — risky primitive; `first_patched_version: null`. Already held at `^6.6.1` via root `resolutions`. Reachable via `@ethersproject/signing-key` and `@walletconnect/utils`.
- **`web3-core-subscriptions` 1.10.4 (#26)** — prototype pollution; `first_patched_version: null`. **Still reachable** after the wagmi/viem consolidation, through `defender-relay-client@1.44.0 → web3-core → web3-core-method → web3-core-subscriptions`. Cannot be eliminated without dropping `defender-relay-client`.

## Test plan

- [x] `pnpm install` clean after adding the override (same pre-existing peer-dep warnings as before; no new ones).
- [x] `pnpm test` — 178/178 passing across 36 files.
- [x] `pnpm build` — green; all SSG/SSR pages generated.
- [ ] `pnpm e2e` — relies on CI (no local .env / Playwright env set up).
- [ ] Manually verify Swagger UI page renders markdown/HTML correctly on the preview deploy.
- [ ] On merge: dismiss alert #118 with the justification above; add a dismissal note to #110, #48, #26 referencing this PR / APP-225.

## Linear

Closes [APP-225](https://linear.app/skybasestar/issue/APP-225/dependabot-wave-4-dompurify-override-lodash-template-audit-sky).