### PR TITLE
Fail-fast Redis client tuning for Upstash on Vercel

### DIFF
--- a/modules/cache/cache.ts
+++ b/modules/cache/cache.ts
@@ -20,14 +20,35 @@ let isConnected = true;
 
 const redis = config.REDIS_URL
   ? new Redis(config.REDIS_URL, {
-      connectTimeout: 10000
+      connectTimeout: 10000,
+      // Serverless fail-fast tuning. Defaults retry each command up to 20
+      // times before surfacing the error, which under a degraded Upstash
+      // connection meant every cache read paid the full retry budget and
+      // logged "Reached the max retries per request limit (which is 20)".
+      // The cache layer treats Redis as best-effort (try/catch + null on
+      // failure), so per-request errors degrade cleanly to "no cache".
+      maxRetriesPerRequest: 1,
+      enableOfflineQueue: false,
+      enableReadyCheck: false,
+      retryStrategy: times => {
+        // Cap reconnect attempts so a dead connection doesn't keep the
+        // lambda alive; the next invocation will open a fresh socket.
+        if (times > 5) return null;
+        return Math.min(times * 200, 1000);
+      }
     })
   : null;
 
 if (redis) {
   redis.on('error', error => {
-    logger.error(error.message);
-    // TODO: Handle error and find better ways to manage reconnects and redis connection status (TODO: Read ioRedis docs)
+    logger.error(`Redis error: ${error.message}`);
+  });
+  // Track connection lifecycle so isConnected reflects current state instead
+  // of latching to false on the first transient error.
+  redis.on('ready', () => {
+    isConnected = true;
+  });
+  redis.on('end', () => {
     isConnected = false;
   });
 }


### PR DESCRIPTION
## Summary

Tunes the ioredis client constructor in `modules/cache/cache.ts` so the cache layer fails fast against a degraded Upstash connection instead of burning every cache read on the default 20-retry budget.

### Why

Production logs on Vercel were filled with:

> Reached the max retries per request limit (which is 20)

That message comes from ioredis's default `maxRetriesPerRequest: 20`. The cache layer already wraps every Redis call in try/catch and falls back to "no cache" on error, so the 20-retry budget was pure overhead — every degraded cache read was paying the full backoff before returning `null`, meaningfully slowing function invocations.

### Changes

- `maxRetriesPerRequest: 1` — surface command errors immediately.
- `enableOfflineQueue: false` — don't queue commands when the socket is down; let them fail and degrade to "no cache".
- `enableReadyCheck: false` — Upstash doesn't reliably expose the `INFO` command used by the ready check; skipping it avoids spurious startup hangs in serverless cold starts.
- `retryStrategy` capped at 5 reconnect attempts so a dead socket can't keep a lambda alive forever; the next invocation gets a fresh connection.
- Stop latching `isConnected` to `false` on the first transient `error` event. Track lifecycle via `ready`/`end` events so reconnects re-enable caching within the same lambda lifetime.

### Risks

Low. Callers already treat Redis as best-effort and handle `null` gracefully. File-cache and mem-cache paths are unchanged. Existing `modules/cache/__tests__/cache.spec.ts` only exercises the file-cache path and still passes.

## Test plan
- [x] `vitest run modules/cache/__tests__/cache.spec.ts` — 3/3 pass
- [x] `tsc --noEmit` clean on `modules/cache/cache.ts`
- [ ] Deploy to Vercel preview and confirm "max retries" log lines disappear
- [ ] Spot-check function durations on cache-heavy endpoints (`/api/executive/*`, `/api/polling/*`) before/after
- [ ] Verify cache hits resume after a simulated Upstash disconnect (kill+restore connection, confirm subsequent reads serve from Redis again rather than staying disabled until lambda restart)

Follow-up to APP-244 review — split out from #95.