### PR TITLE
Pass chainId to the proxy indexer endpoint

### DIFF
--- a/modules/gql/__tests__/gqlRequest.spec.ts
+++ b/modules/gql/__tests__/gqlRequest.spec.ts
@@ -1,0 +1,55 @@
+/*
+
+SPDX-FileCopyrightText: © 2026 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { gqlRequest } from '../gqlRequest';
+import { SupportedChainId } from 'modules/web3/constants/chainID';
+import { CHAIN_INFO } from 'modules/web3/constants/networks';
+
+describe('gqlRequest URL construction', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ data: { ok: true } }),
+      text: async () => ''
+    } as unknown as Response);
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('appends mainnet chainId to the indexer URL', async () => {
+    await gqlRequest({ chainId: SupportedChainId.MAINNET, query: '{__typename}' });
+
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toBe(`${CHAIN_INFO[SupportedChainId.MAINNET].subgraphUrl}/1`);
+    expect(calledUrl.endsWith('/indexer/1')).toBe(true);
+  });
+
+  it('appends tenderly chainId to the indexer URL', async () => {
+    await gqlRequest({ chainId: SupportedChainId.TENDERLY, query: '{__typename}' });
+
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toBe(`${CHAIN_INFO[SupportedChainId.TENDERLY].subgraphUrl}/314310`);
+    expect(calledUrl.endsWith('/indexer/314310')).toBe(true);
+  });
+
+  it('falls back to mainnet chainId when none is passed', async () => {
+    await gqlRequest({ query: '{__typename}' });
+
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl.endsWith('/indexer/1')).toBe(true);
+  });
+});

--- a/modules/gql/gql.constants.ts
+++ b/modules/gql/gql.constants.ts
@@ -6,13 +6,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 */
 
-/* Envio HyperIndex URLs (proxied via proxy.sky.money) */
+/* Envio HyperIndex URL (proxied via proxy.sky.money) */
 
 const PROXY_ORIGIN = process.env.NEXT_PUBLIC_PROXY_ORIGIN || 'https://staging-proxy.sky.money';
-const ENVIO_INDEXER_URL = `${PROXY_ORIGIN}/indexer`;
 
-export const STAGING_SUBGRAPH_URL = ENVIO_INDEXER_URL;
-export const PROD_SUBGRAPH_URL = ENVIO_INDEXER_URL;
+export const INDEXER_URL = `${PROXY_ORIGIN}/indexer`;
 
 export const stakingEngineAddressMainnet = '0xce01c90de7fd1bcfa39e237fe6d8d9f569e8a6a3';
 export const stakingEngineAddressTestnet = '0xce01c90de7fd1bcfa39e237fe6d8d9f569e8a6a3';

--- a/modules/gql/gqlRequest.ts
+++ b/modules/gql/gqlRequest.ts
@@ -26,10 +26,11 @@ export const gqlRequest = async <TQuery = any>({
 }: GqlRequestProps): Promise<TQuery> => {
   try {
     const id = chainId ?? SupportedChainId.MAINNET;
-    const url = CHAIN_INFO[id].subgraphUrl;
-    if (!url) {
+    const baseUrl = CHAIN_INFO[id].subgraphUrl;
+    if (!baseUrl) {
       return Promise.reject(new ApiError(`Missing subgraph url in configuration for chainId: ${id}`));
     }
+    const url = `${baseUrl}/${id}`;
 
     const resp = await backoffRetry(
       1,

--- a/modules/web3/constants/networks.ts
+++ b/modules/web3/constants/networks.ts
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import { SupportedChain } from '../types/chain';
 import { SupportedChainId } from './chainID';
 
-import { STAGING_SUBGRAPH_URL, PROD_SUBGRAPH_URL } from 'modules/gql/gql.constants';
+import { INDEXER_URL } from 'modules/gql/gql.constants';
 
 export enum SupportedConnectors {
   METAMASK = 'MetaMask',
@@ -46,7 +46,7 @@ export const CHAIN_INFO: ChainInfo = {
     label: 'Mainnet',
     type: 'normal',
     network: SupportedNetworks.MAINNET,
-    subgraphUrl: PROD_SUBGRAPH_URL,
+    subgraphUrl: INDEXER_URL,
     showInProduction: true
   },
   [SupportedChainId.ARBITRUMTESTNET]: {
@@ -56,7 +56,7 @@ export const CHAIN_INFO: ChainInfo = {
     label: 'ArbitrumTestnet',
     type: 'gasless',
     network: SupportedNetworks.ARBITRUMTESTNET,
-    subgraphUrl: STAGING_SUBGRAPH_URL,
+    subgraphUrl: INDEXER_URL,
     showInProduction: false
   },
   [SupportedChainId.ARBITRUM]: {
@@ -66,7 +66,7 @@ export const CHAIN_INFO: ChainInfo = {
     label: 'Arbitrum',
     type: 'gasless',
     network: SupportedNetworks.ARBITRUM,
-    subgraphUrl: PROD_SUBGRAPH_URL,
+    subgraphUrl: INDEXER_URL,
     showInProduction: false
   },
   [SupportedChainId.TENDERLY]: {
@@ -76,7 +76,7 @@ export const CHAIN_INFO: ChainInfo = {
     label: 'Tenderly',
     type: 'normal',
     network: SupportedNetworks.TENDERLY,
-    subgraphUrl: STAGING_SUBGRAPH_URL,
+    subgraphUrl: INDEXER_URL,
     showInProduction: false
   }
 };


### PR DESCRIPTION
## Summary

- The proxy worker recently added `POST /indexer/:chainId` ([api-workers#71](https://github.com/skybase-foundation/api-workers/pull/71)) which routes chainId `314310` to a Tenderly-specific Envio indexer and falls all other chainIds through to the default. The bare `/indexer` path is unchanged on the server, so this is non-breaking either direction.
- This repo already routes all GraphQL traffic through a single chokepoint (`gqlRequest({ chainId, query })` at `modules/gql/gqlRequest.ts`), and every call site (client hooks, API routes, `getStaticProps`) already passes a chainId — so the change collapses to one URL-construction tweak rather than a wide hook refactor like [tarmac#1556](https://github.com/jetstreamgg/tarmac/pull/1556).
- Also collapses the now-redundant `STAGING_SUBGRAPH_URL` / `PROD_SUBGRAPH_URL` aliases (both already equal to `${PROXY_ORIGIN}/indexer`) into a single `INDEXER_URL` export.
- Adds `modules/gql/__tests__/gqlRequest.spec.ts` asserting the URL shape for mainnet, Tenderly, and the default-chainId fallback.

## Test plan

- [x] `pnpm exec vitest run` — 181/181 pass, including 3 new `gqlRequest` URL specs
- [x] `pnpm exec tsc --noEmit` — no new errors in changed files (only pre-existing test-file errors unrelated to this PR)
- [ ] Dev smoke against staging on **mainnet**: open polling / delegates / executive vote tally and confirm DevTools shows `https://staging-proxy.sky.money/indexer/1` returning 200
- [ ] Dev smoke against staging on **Tenderly** (chainId 314310): requests should hit `/indexer/314310`. If `ENVIO_INDEXER_URL_TENDERLY` isn't set in the proxy environment yet, expect 500 from the proxy — that's documented behaviour in api-workers#71, not a client bug
- [ ] Regression smoke on Arbitrum (`/indexer/42161`) — falls through to default indexer per the proxy's logic