### PR TITLE
Fix header paddings

### DIFF
--- a/modules/app/components/layout/Header.tsx
+++ b/modules/app/components/layout/Header.tsx
@@ -132,7 +132,7 @@ const Header = (): JSX.Element => {
     <Box
       as="header"
       pt={3}
-      pb={2}
+      pb={3}
       px={3}
       sx={{
         display: 'flex',


### PR DESCRIPTION
https://linear.app/ekliptyka/issue/APP-14/fix-header-alignment-in-sky-gov-portal

<img width="452" height="174" alt="image" src="https://github.com/user-attachments/assets/f841d305-a7a1-4aff-b473-c3887e88e86e" />

Observed issue (from screenshot)

Very small thing, but the header in the Gov portal is using a different amount of padding on top and bottom, which makes it look like the content is not properly aligned to the center.

The top-bar container has asymmetric vertical padding (top ≠ bottom), so the logo / nav links / wallet button sit slightly above or below the visual midline of the bar instead of being centered.

Fixed version preview: https://sky-governance-portal-1fohg9043-skybase-international.vercel.app/
