### PR TITLE
Release: ballot tally deduplication fix, header paddings, pnpm v11 upgrade

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 11.3.0
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 11.3.0
+          version: 11.5.0
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 11.3.0
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 11.3.0
+          version: 11.5.0
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 11.3.0
+          version: 11.5.0
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 11.3.0
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-script-shell = bash
-minimum-release-age=10080

--- a/modules/app/components/layout/Header.tsx
+++ b/modules/app/components/layout/Header.tsx
@@ -132,7 +132,7 @@ const Header = (): JSX.Element => {
     <Box
       as="header"
       pt={3}
-      pb={2}
+      pb={3}
       px={3}
       sx={{
         display: 'flex',

--- a/modules/polling/api/__tests__/fetchTallyAmplification.spec.ts
+++ b/modules/polling/api/__tests__/fetchTallyAmplification.spec.ts
@@ -1,0 +1,195 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+/**
+ * Regression test for Immunefi #82775.
+ *
+ * The polling contract emits a raw optionId that the app decodes byte-by-byte into
+ * one ballot entry per byte. Without cardinality validation, a single-choice voter
+ * could submit a raw value whose bytes repeat the same option (e.g. 0x0101...01) and
+ * have their weight counted once per byte, multiplying their support for an option and
+ * flipping the active poll winner.
+ *
+ * These tests exercise fetchPollTally end-to-end and assert that:
+ *  - a duplicated-byte ballot is counted exactly once (no amplification, no winner flip);
+ *  - a single-choice ballot that decodes to multiple distinct options is discarded.
+ */
+
+import { PollInputFormat, PollResultDisplay, PollVictoryConditions } from 'modules/polling/polling.constants';
+import { Poll } from 'modules/polling/types';
+import { SupportedNetworks } from 'modules/web3/constants/networks';
+import { gqlRequest } from '../../../../modules/gql/gqlRequest';
+import { fetchPollTally } from '../fetchPollTally';
+import { Mock, vi } from 'vitest';
+
+vi.mock('modules/gql/gqlRequest');
+
+// 0x0101010101010101 -> decodes to [1, 1, 1, 1, 1, 1, 1, 1] before dedup (8x amplification attempt)
+const AMPLIFIED_YES_CHOICE = '72340172838076673';
+// 0x0201 -> decodes to [1, 2]: two distinct options, invalid for a single-choice poll
+const MULTI_OPTION_CHOICE = '513';
+
+const singleChoicePoll: Poll = {
+  pollId: 1,
+  options: {
+    '0': 'Abstain',
+    '1': 'Yes',
+    '2': 'No'
+  },
+  parameters: {
+    inputFormat: {
+      type: PollInputFormat.singleChoice,
+      abstain: [0],
+      options: []
+    },
+    resultDisplay: PollResultDisplay.singleVoteBreakdown,
+    victoryConditions: [
+      {
+        type: PollVictoryConditions.majority,
+        percent: 50
+      }
+    ]
+  }
+} as any as Poll;
+
+describe('Fetch tally - ballot amplification (Immunefi #82775)', () => {
+  it('counts a duplicated-byte single-choice ballot once and does not flip the winner', async () => {
+    (gqlRequest as Mock)
+      .mockResolvedValueOnce({}) // fetchDelegateAddresses
+      .mockResolvedValueOnce({ pollVotes: [] }) // mainnet voters
+      .mockResolvedValueOnce({
+        arbitrumPoll: {
+          votes: [
+            // Attacker: small weight (10 SKY) on "Yes", raw choice packs 8 repeated bytes.
+            { voter: { id: '0x123' }, choice: AMPLIFIED_YES_CHOICE },
+            // Honest voter: 60 SKY on "No".
+            { voter: { id: '0x456' }, choice: '2' }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        voters: [
+          { id: '0x123', v2VotingPowerChanges: [{ newBalance: '10000000000000000000' }] },
+          { id: '0x456', v2VotingPowerChanges: [{ newBalance: '60000000000000000000' }] }
+        ]
+      });
+
+    const result = await fetchPollTally(singleChoicePoll, SupportedNetworks.MAINNET);
+
+    const yes = result.results.find(r => r.optionId === 1);
+    const no = result.results.find(r => r.optionId === 2);
+
+    // "Yes" weight is counted once (10), not amplified to 80.
+    expect(yes?.skySupport).toBe('10');
+    expect(no?.skySupport).toBe('60');
+
+    // Honest majority stands: "No" wins, the attacker does not flip the poll.
+    expect(result.winner).toBe(2);
+    expect(result.winningOptionName).toBe('No');
+    expect(no?.winner).toBe(true);
+    expect(yes?.winner).toBe(false);
+    expect(result.numVoters).toBe(2);
+  });
+
+  it('discards a single-choice ballot that decodes to multiple distinct options', async () => {
+    (gqlRequest as Mock)
+      .mockResolvedValueOnce({}) // fetchDelegateAddresses
+      .mockResolvedValueOnce({ pollVotes: [] }) // mainnet voters
+      .mockResolvedValueOnce({
+        arbitrumPoll: {
+          votes: [
+            // Malformed single-choice ballot voting for options 1 and 2 at once, large weight.
+            { voter: { id: '0x123' }, choice: MULTI_OPTION_CHOICE },
+            // Honest voter: 60 SKY on "No".
+            { voter: { id: '0x456' }, choice: '2' }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        voters: [
+          { id: '0x123', v2VotingPowerChanges: [{ newBalance: '100000000000000000000' }] },
+          { id: '0x456', v2VotingPowerChanges: [{ newBalance: '60000000000000000000' }] }
+        ]
+      });
+
+    const result = await fetchPollTally(singleChoicePoll, SupportedNetworks.MAINNET);
+
+    const yes = result.results.find(r => r.optionId === 1);
+    const no = result.results.find(r => r.optionId === 2);
+
+    // The malformed ballot is dropped entirely: it contributes to neither option nor participation.
+    expect(yes?.skySupport).toBe('0');
+    expect(no?.skySupport).toBe('60');
+    expect(result.numVoters).toBe(1);
+    expect(result.totalSkyParticipation).toBe('60');
+    expect(result.winner).toBe(2);
+  });
+});
+
+// The amplification vector was never single-choice specific: an approval (choose-free)
+// poll counts every option in a ballot, so duplicated bytes would inflate an option there
+// too. The dedup in parseRawOptionId neutralizes this for every format, while legitimate
+// multi-option approval ballots must still count each distinct option once.
+const chooseFreePoll: Poll = {
+  pollId: 2,
+  options: {
+    '0': 'Abstain',
+    '1': 'Option A',
+    '2': 'Option B'
+  },
+  parameters: {
+    inputFormat: {
+      type: PollInputFormat.chooseFree,
+      abstain: [0],
+      options: []
+    },
+    resultDisplay: PollResultDisplay.approvalBreakdown,
+    victoryConditions: [
+      {
+        type: PollVictoryConditions.majority,
+        percent: 50
+      }
+    ]
+  }
+} as any as Poll;
+
+describe('Fetch tally - approval poll is not amplifiable (Immunefi #82775)', () => {
+  it('counts a duplicated-byte option once while still counting a legitimate multi-option ballot', async () => {
+    (gqlRequest as Mock)
+      .mockResolvedValueOnce({}) // fetchDelegateAddresses
+      .mockResolvedValueOnce({ pollVotes: [] }) // mainnet voters
+      .mockResolvedValueOnce({
+        arbitrumPoll: {
+          votes: [
+            // Honest voter legitimately approves both A and B (0x0201 -> [1, 2]), 40 SKY.
+            { voter: { id: '0x123' }, choice: MULTI_OPTION_CHOICE },
+            // Attacker approves only A with 8 repeated bytes, 10 SKY.
+            { voter: { id: '0x456' }, choice: AMPLIFIED_YES_CHOICE }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        voters: [
+          { id: '0x123', v2VotingPowerChanges: [{ newBalance: '40000000000000000000' }] },
+          { id: '0x456', v2VotingPowerChanges: [{ newBalance: '10000000000000000000' }] }
+        ]
+      });
+
+    const result = await fetchPollTally(chooseFreePoll, SupportedNetworks.MAINNET);
+
+    const optionA = result.results.find(r => r.optionId === 1);
+    const optionB = result.results.find(r => r.optionId === 2);
+
+    // Option A: 40 (honest) + 10 (attacker counted once) = 50, NOT 40 + 80.
+    expect(optionA?.skySupport).toBe('50');
+    // Option B: only the honest multi-option ballot counts it = 40.
+    expect(optionB?.skySupport).toBe('40');
+    expect(result.numVoters).toBe(2);
+    expect(result.totalSkyParticipation).toBe('50');
+  });
+});

--- a/modules/polling/api/fetchPollTally.ts
+++ b/modules/polling/api/fetchPollTally.ts
@@ -16,7 +16,7 @@ import { extractWinnerInstantRunoff } from './victory_conditions/instantRunoff';
 import { extractWinnerDefault } from './victory_conditions/default';
 import { InstantRunoffResults } from '../types/instantRunoff';
 import { extractSatisfiesComparison } from './victory_conditions/comparison';
-import { hasVictoryConditionInstantRunOff } from '../helpers/utils';
+import { hasVictoryConditionInstantRunOff, isInputFormatSingleChoice } from '../helpers/utils';
 import { fetchVotesByAddressForPoll } from './fetchVotesByAddress';
 import { calculatePercentage } from 'lib/utils';
 import { formatEther, parseEther } from 'viem';
@@ -73,7 +73,18 @@ export async function fetchPollTally(poll: Poll, network: SupportedNetworks): Pr
   });
 
   // Fetch votes for the poll
-  const votesByAddress = await fetchVotesByAddressForPoll(poll.pollId, ownerToDelegateMap, network);
+  const rawVotesByAddress = await fetchVotesByAddressForPoll(poll.pollId, ownerToDelegateMap, network);
+
+  // Cardinality guard: a single-choice poll must carry exactly one option per ballot.
+  // Ballots that decode to a different number of options are malformed for this format
+  // and are discarded rather than counted, so a voter cannot split or multiply their
+  // weight across options. Together with the deduplication in parseRawOptionId this
+  // closes the vote-amplification vector (Immunefi #82775). Other formats (ranked-choice,
+  // approval) legitimately carry multiple distinct options and are left untouched.
+  // isInputFormatSingleChoice also handles the legacy string-shaped inputFormat.
+  const votesByAddress = isInputFormatSingleChoice(poll.parameters)
+    ? rawVotesByAddress.filter(vote => vote.ballot.length === 1)
+    : rawVotesByAddress;
 
   // Abstain
   const abstain = poll.parameters.inputFormat.abstain ? poll.parameters.inputFormat.abstain : [0];

--- a/modules/polling/helpers/__tests__/parseRawOptionId.spec.ts
+++ b/modules/polling/helpers/__tests__/parseRawOptionId.spec.ts
@@ -1,0 +1,42 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import { parseRawOptionId } from '../parseRawOptionId';
+
+describe('parseRawOptionId', () => {
+  it('returns an empty ballot for an empty or undefined raw value', () => {
+    expect(parseRawOptionId(undefined)).toEqual([]);
+    expect(parseRawOptionId('')).toEqual([]);
+  });
+
+  it('decodes a single-option ballot', () => {
+    expect(parseRawOptionId('1')).toEqual([1]);
+    expect(parseRawOptionId('2')).toEqual([2]);
+  });
+
+  it('decodes a ranked ballot preserving order', () => {
+    // 0x030102 -> option ranking [2, 1, 3]
+    expect(parseRawOptionId('196866')).toEqual([2, 1, 3]);
+  });
+
+  // Regression: Immunefi #82775 - a raw optionId whose bytes repeat the same option
+  // must not inflate that option's weight. Duplicates are collapsed to a single entry.
+  it('deduplicates repeated options so weight cannot be multiplied', () => {
+    // 0x0101 -> [1, 1] before dedup
+    expect(parseRawOptionId('257')).toEqual([1]);
+    // 0x0101010101010101 -> [1, 1, 1, 1, 1, 1, 1, 1] before dedup (8x amplification attempt)
+    expect(parseRawOptionId('72340172838076673')).toEqual([1]);
+  });
+
+  it('deduplicates while keeping the first occurrence and ranking order', () => {
+    // 0x010201 -> [1, 2, 1] before dedup -> [1, 2]
+    expect(parseRawOptionId('66049')).toEqual([1, 2]);
+    // 0x02030103 -> [3, 1, 3, 2] before dedup -> [3, 1, 2]
+    expect(parseRawOptionId('33751299')).toEqual([3, 1, 2]);
+  });
+});

--- a/modules/polling/helpers/parseRawOptionId.ts
+++ b/modules/polling/helpers/parseRawOptionId.ts
@@ -16,5 +16,11 @@ export function parseRawOptionId(rawValue?: string): number[] {
     voteBallot = ballot.reverse();
   }
 
-  return voteBallot;
+  // A voter can never legitimately rank or approve the same option twice, in any
+  // poll format (single-choice, ranked-choice or approval). Duplicate bytes in the
+  // raw optionId would otherwise be counted once per occurrence during tallying,
+  // letting a single voter multiply their own weight for an option (Immunefi #82775).
+  // A Set preserves insertion order and keeps the first occurrence, so the ranking
+  // order used by instant-runoff polls is left intact.
+  return [...new Set(voteBallot)];
 }

--- a/package.json
+++ b/package.json
@@ -110,36 +110,5 @@
     "vitest": "^3.0.9",
     "wait-for-expect": "^3.0.2"
   },
-  "resolutions": {
-    "elliptic": "^6.6.1"
-  },
-  "pnpm": {
-    "overrides": {
-      "axios@<1": "^0.31.1",
-      "axios@^1": "^1.15.2",
-      "protobufjs@^6": "7.5.5",
-      "protobufjs@^7": "7.5.5",
-      "unstorage@>=1 <2": "^1.17.5",
-      "bn.js@<5": "^4.12.3",
-      "immutable@<4": "^3.8.3",
-      "yaml@<2": "^1.10.3",
-      "js-yaml@<4": "^3.14.2",
-      "js-yaml@>=4": "^4.1.1",
-      "validator": "^13.15.22",
-      "prismjs": "^1.30.0",
-      "ws@>=7 <8": "^7.5.10",
-      "@metamask/sdk": "^0.33.1",
-      "@metamask/sdk-communication-layer": "^0.33.1",
-      "serialize-javascript": "^7.0.5",
-      "postcss@>=8 <9": "^8.5.10",
-      "vite@>=6 <7": "^6.4.2",
-      "brace-expansion@>=1 <2": "^1.1.14",
-      "dompurify": "^3.4.0",
-      "rollup@>=4 <5": "^4.59.0",
-      "webpack@>=5 <6": "^5.104.1",
-      "diff@>=5 <6": "^5.2.2",
-      "esbuild@<0.25.0": "^0.25.0"
-    }
-  },
-  "packageManager": "pnpm@10.17.0"
+  "packageManager": "pnpm@11.3.0"
 }

--- a/package.json
+++ b/package.json
@@ -110,5 +110,5 @@
     "vitest": "^3.0.9",
     "wait-for-expect": "^3.0.2"
   },
-  "packageManager": "pnpm@11.3.0"
+  "packageManager": "pnpm@11.5.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,16 +215,16 @@ importers:
         version: 18.3.9
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.59.2
-        version: 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2))(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
+        version: 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2))(eslint@9.39.4)(typescript@5.8.2)
       '@typescript-eslint/parser':
         specifier: ^8.59.2
-        version: 8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
+        version: 8.59.2(eslint@9.39.4)(typescript@5.8.2)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.46.2))
+        version: 4.3.4(vite@6.4.2(@types/node@20.17.23)(terser@5.46.2))
       '@vitest/coverage-v8':
         specifier: ^3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.17.23)(happy-dom@20.9.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@1.21.0)(terser@5.46.2))
+        version: 3.0.9(vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.17.23)(happy-dom@20.9.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(terser@5.46.2))
       '@wagmi/cli':
         specifier: ^2.2.0
         version: 2.2.0(bufferutil@4.1.0)(typescript@5.8.2)(utf-8-validate@5.0.10)
@@ -236,25 +236,25 @@ importers:
         version: 8.6.0
       eslint:
         specifier: ^9.39.4
-        version: 9.39.4(jiti@1.21.0)
+        version: 9.39.4
       eslint-config-next:
         specifier: ^15.5.15
-        version: 15.5.15(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
+        version: 15.5.15(eslint@9.39.4)(typescript@5.8.2)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.4(jiti@1.21.0))
+        version: 10.1.8(eslint@9.39.4)
       eslint-plugin-jest-dom:
         specifier: ^5.5.0
-        version: 5.5.0(@testing-library/dom@10.4.0)(eslint@9.39.4(jiti@1.21.0))
+        version: 5.5.0(@testing-library/dom@10.4.0)(eslint@9.39.4)
       eslint-plugin-prettier:
         specifier: ^5.5.5
-        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@1.21.0)))(eslint@9.39.4(jiti@1.21.0))(prettier@2.8.8)
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@2.8.8)
       eslint-plugin-react:
         specifier: ^7.37.5
-        version: 7.37.5(eslint@9.39.4(jiti@1.21.0))
+        version: 7.37.5(eslint@9.39.4)
       eslint-plugin-testing-library:
         specifier: ^7.16.2
-        version: 7.16.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
+        version: 7.16.2(eslint@9.39.4)(typescript@5.8.2)
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
@@ -281,10 +281,10 @@ importers:
         version: 5.8.2
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.2)(vite@6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.46.2))
+        version: 5.1.4(typescript@5.8.2)(vite@6.4.2(@types/node@20.17.23)(terser@5.46.2))
       vitest:
         specifier: ^3.0.9
-        version: 3.0.9(@types/debug@4.1.12)(@types/node@20.17.23)(happy-dom@20.9.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@1.21.0)(terser@5.46.2)
+        version: 3.0.9(@types/debug@4.1.12)(@types/node@20.17.23)(happy-dom@20.9.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(terser@5.46.2)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -992,6 +992,7 @@ packages:
 
   '@metamask/sdk-analytics@0.0.5':
     resolution: {integrity: sha512-fDah+keS1RjSUlC8GmYXvx6Y26s3Ax1U9hGpWb6GSY5SAdmTSIqp2CvYy6yW0WgLhnYhW+6xERuD0eVqV63QIQ==}
+    deprecated: No longer maintained, superseded by @metamask/connect-analytics
 
   '@metamask/sdk-communication-layer@0.33.1':
     resolution: {integrity: sha512-0bI9hkysxcfbZ/lk0T2+aKVo1j0ynQVTuB3sJ5ssPWlz+Z3VwveCkP1O7EVu1tsVVCb0YV5WxK9zmURu2FIiaA==}
@@ -1005,6 +1006,7 @@ packages:
 
   '@metamask/sdk-install-modal-web@0.32.1':
     resolution: {integrity: sha512-MGmAo6qSjf1tuYXhCu2EZLftq+DSt5Z7fsIKr2P+lDgdTPWgLfZB1tJKzNcwKKOdf6q9Qmmxn7lJuI/gq5LrKw==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/sdk@0.33.1':
     resolution: {integrity: sha512-1mcOQVGr9rSrVcbKPNVzbZ8eCl1K0FATsYH3WJ/MH4WcZDWGECWrXJPNMZoEAkLxWiMe8jOQBumg2pmcDa9zpQ==}
@@ -1149,7 +1151,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'The package is now available as "qr": npm install qr'
+    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1494,6 +1496,7 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.22.9':
     resolution: {integrity: sha512-7ojVK/crhOaGowEO8uYWaopZzcr5rR76emgllGIfjCLR70aY4PbASpi9Pbs+7jIRzPDBBkM0RBo+zYx5UduX8Q==}
     engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
@@ -4258,10 +4261,6 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
 
-  jiti@1.21.0:
-    resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
-    hasBin: true
-
   js-file-download@0.4.12:
     resolution: {integrity: sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==}
 
@@ -5377,6 +5376,7 @@ packages:
   recharts@2.9.0:
     resolution: {integrity: sha512-cVgiAU3W5UrA8nRRV/N0JrudgZzY/vjkzrlShbH+EFo1vs4nMlXgshZWLI0DfDLmn4/p4pF7Lq7F5PU+K94Ipg==}
     engines: {node: '>=12'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       prop-types: ^15.6.0
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
@@ -7083,9 +7083,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
     dependencies:
-      eslint: 9.39.4(jiti@1.21.0)
+      eslint: 9.39.4
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -8849,15 +8849,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2))(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)':
+  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2))(eslint@9.39.4)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4)(typescript@5.8.2)
       '@typescript-eslint/scope-manager': 8.59.2
-      '@typescript-eslint/type-utils': 8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
+      '@typescript-eslint/type-utils': 8.59.2(eslint@9.39.4)(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4)(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.59.2
-      eslint: 9.39.4(jiti@1.21.0)
+      eslint: 9.39.4
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.8.2)
@@ -8865,14 +8865,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)':
+  '@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.2
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.59.2
       debug: 4.4.3
-      eslint: 9.39.4(jiti@1.21.0)
+      eslint: 9.39.4
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
@@ -8895,13 +8895,13 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
-  '@typescript-eslint/type-utils@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)':
+  '@typescript-eslint/type-utils@8.59.2(eslint@9.39.4)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.8.2)
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4)(typescript@5.8.2)
       debug: 4.4.3
-      eslint: 9.39.4(jiti@1.21.0)
+      eslint: 9.39.4
       ts-api-utils: 2.5.0(typescript@5.8.2)
       typescript: 5.8.2
     transitivePeerDependencies:
@@ -8924,13 +8924,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)':
+  '@typescript-eslint/utils@8.59.2(eslint@9.39.4)(typescript@5.8.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
       '@typescript-eslint/scope-manager': 8.59.2
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.8.2)
-      eslint: 9.39.4(jiti@1.21.0)
+      eslint: 9.39.4
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
@@ -8944,18 +8944,18 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@vitejs/plugin-react@4.3.4(vite@6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.46.2))':
+  '@vitejs/plugin-react@4.3.4(vite@6.4.2(@types/node@20.17.23)(terser@5.46.2))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.46.2)
+      vite: 6.4.2(@types/node@20.17.23)(terser@5.46.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.0.9(vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.17.23)(happy-dom@20.9.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@1.21.0)(terser@5.46.2))':
+  '@vitest/coverage-v8@3.0.9(vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.17.23)(happy-dom@20.9.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(terser@5.46.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -8969,7 +8969,7 @@ snapshots:
       std-env: 3.8.1
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@20.17.23)(happy-dom@20.9.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@1.21.0)(terser@5.46.2)
+      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@20.17.23)(happy-dom@20.9.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(terser@5.46.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -8980,13 +8980,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.9(vite@6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.46.2))':
+  '@vitest/mocker@3.0.9(vite@6.4.2(@types/node@20.17.23)(terser@5.46.2))':
     dependencies:
       '@vitest/spy': 3.0.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.46.2)
+      vite: 6.4.2(@types/node@20.17.23)(terser@5.46.2)
 
   '@vitest/pretty-format@3.0.9':
     dependencies:
@@ -10619,28 +10619,28 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@15.5.15(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2):
+  eslint-config-next@15.5.15(eslint@9.39.4)(typescript@5.8.2):
     dependencies:
       '@next/eslint-plugin-next': 15.5.15
       '@rushstack/eslint-patch': 1.16.1
-      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2))(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
-      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
-      eslint: 9.39.4(jiti@1.21.0)
+      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2))(eslint@9.39.4)(typescript@5.8.2)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4)(typescript@5.8.2)
+      eslint: 9.39.4
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4(jiti@1.21.0))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.0))
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.0))
-      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4(jiti@1.21.0))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.4)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4)
+      eslint-plugin-react: 7.37.5(eslint@9.39.4)
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4)
     optionalDependencies:
       typescript: 5.8.2
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@1.21.0)):
+  eslint-config-prettier@10.1.8(eslint@9.39.4):
     dependencies:
-      eslint: 9.39.4(jiti@1.21.0)
+      eslint: 9.39.4
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
@@ -10650,13 +10650,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.0)):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.4):
     dependencies:
       debug: 4.4.3
       enhanced-resolve: 5.17.1
-      eslint: 9.39.4(jiti@1.21.0)
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4(jiti@1.21.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4(jiti@1.21.0))
+      eslint: 9.39.4
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -10667,29 +10667,29 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4(jiti@1.21.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
-      eslint: 9.39.4(jiti@1.21.0)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4)(typescript@5.8.2)
+      eslint: 9.39.4
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.0))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4(jiti@1.21.0)):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
-      eslint: 9.39.4(jiti@1.21.0)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4)(typescript@5.8.2)
+      eslint: 9.39.4
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.0))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4(jiti@1.21.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10698,9 +10698,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@1.21.0)
+      eslint: 9.39.4
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4(jiti@1.21.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10712,21 +10712,21 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4)(typescript@5.8.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest-dom@5.5.0(@testing-library/dom@10.4.0)(eslint@9.39.4(jiti@1.21.0)):
+  eslint-plugin-jest-dom@5.5.0(@testing-library/dom@10.4.0)(eslint@9.39.4):
     dependencies:
       '@babel/runtime': 7.27.0
-      eslint: 9.39.4(jiti@1.21.0)
+      eslint: 9.39.4
       requireindex: 1.2.0
     optionalDependencies:
       '@testing-library/dom': 10.4.0
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@1.21.0)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.8
@@ -10736,7 +10736,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.4(jiti@1.21.0)
+      eslint: 9.39.4
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -10745,21 +10745,21 @@ snapshots:
       safe-regex-test: 1.0.3
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@1.21.0)))(eslint@9.39.4(jiti@1.21.0))(prettier@2.8.8):
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@2.8.8):
     dependencies:
-      eslint: 9.39.4(jiti@1.21.0)
+      eslint: 9.39.4
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
       '@types/eslint': 9.6.1
-      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@1.21.0))
+      eslint-config-prettier: 10.1.8(eslint@9.39.4)
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@1.21.0)):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.4):
     dependencies:
-      eslint: 9.39.4(jiti@1.21.0)
+      eslint: 9.39.4
 
-  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@1.21.0)):
+  eslint-plugin-react@7.37.5(eslint@9.39.4):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -10767,7 +10767,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.2
-      eslint: 9.39.4(jiti@1.21.0)
+      eslint: 9.39.4
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -10781,11 +10781,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-testing-library@7.16.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2):
+  eslint-plugin-testing-library@7.16.2(eslint@9.39.4)(typescript@5.8.2):
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.2
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@1.21.0))(typescript@5.8.2)
-      eslint: 9.39.4(jiti@1.21.0)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4)(typescript@5.8.2)
+      eslint: 9.39.4
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10806,9 +10806,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.4(jiti@1.21.0):
+  eslint@9.39.4:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.2
       '@eslint/config-helpers': 0.4.2
@@ -10842,8 +10842,6 @@ snapshots:
       minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
-    optionalDependencies:
-      jiti: 1.21.0
     transitivePeerDependencies:
       - supports-color
 
@@ -11803,9 +11801,6 @@ snapshots:
       '@types/node': 20.19.30
       merge-stream: 2.0.0
       supports-color: 8.1.1
-
-  jiti@1.21.0:
-    optional: true
 
   js-file-download@0.4.12: {}
 
@@ -14254,13 +14249,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-node@3.0.9(@types/node@20.17.23)(jiti@1.21.0)(terser@5.46.2):
+  vite-node@3.0.9(@types/node@20.17.23)(terser@5.46.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.46.2)
+      vite: 6.4.2(@types/node@20.17.23)(terser@5.46.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14275,18 +14270,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.46.2)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.4.2(@types/node@20.17.23)(terser@5.46.2)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.8.2)
     optionalDependencies:
-      vite: 6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.46.2)
+      vite: 6.4.2(@types/node@20.17.23)(terser@5.46.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.46.2):
+  vite@6.4.2(@types/node@20.17.23)(terser@5.46.2):
     dependencies:
       esbuild: 0.25.1
       fdir: 6.5.0(picomatch@4.0.4)
@@ -14297,13 +14292,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.17.23
       fsevents: 2.3.3
-      jiti: 1.21.0
       terser: 5.46.2
 
-  vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.17.23)(happy-dom@20.9.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@1.21.0)(terser@5.46.2):
+  vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.17.23)(happy-dom@20.9.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(terser@5.46.2):
     dependencies:
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(vite@6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.46.2))
+      '@vitest/mocker': 3.0.9(vite@6.4.2(@types/node@20.17.23)(terser@5.46.2))
       '@vitest/pretty-format': 3.0.9
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9
@@ -14319,8 +14313,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.4.2(@types/node@20.17.23)(jiti@1.21.0)(terser@5.46.2)
-      vite-node: 3.0.9(@types/node@20.17.23)(jiti@1.21.0)(terser@5.46.2)
+      vite: 6.4.2(@types/node@20.17.23)(terser@5.46.2)
+      vite-node: 3.0.9(@types/node@20.17.23)(terser@5.46.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,42 @@
+minimumReleaseAge: 10080
+scriptShell: bash
+
+overrides:
+  elliptic: ^6.6.1
+  axios@<1: ^0.31.1
+  axios@^1: ^1.15.2
+  protobufjs@^6: 7.5.5
+  protobufjs@^7: 7.5.5
+  unstorage@>=1 <2: ^1.17.5
+  bn.js@<5: ^4.12.3
+  immutable@<4: ^3.8.3
+  yaml@<2: ^1.10.3
+  js-yaml@<4: ^3.14.2
+  js-yaml@>=4: ^4.1.1
+  validator: ^13.15.22
+  prismjs: ^1.30.0
+  ws@>=7 <8: ^7.5.10
+  "@metamask/sdk": ^0.33.1
+  "@metamask/sdk-communication-layer": ^0.33.1
+  serialize-javascript: ^7.0.5
+  postcss@>=8 <9: ^8.5.10
+  vite@>=6 <7: ^6.4.2
+  brace-expansion@>=1 <2: ^1.1.14
+  dompurify: ^3.4.0
+  rollup@>=4 <5: ^4.59.0
+  webpack@>=5 <6: ^5.104.1
+  diff@>=5 <6: ^5.2.2
+  esbuild@<0.25.0: ^0.25.0
+
+allowBuilds:
+  '@scarf/scarf': false
+  '@tree-sitter-grammars/tree-sitter-yaml': false
+  bufferutil: false
+  core-js-pure: false
+  esbuild: false
+  keccak: false
+  protobufjs: false
+  sharp: false
+  tree-sitter: false
+  tree-sitter-json: false
+  utf-8-validate: false


### PR DESCRIPTION
### What does this PR do?

This PR brings the latest changes from development into main:

- Security fix: ballot option deduplication in poll tally (Immunefi #82775). A raw optionId whose bytes repeated the same option was decoded into one ballot entry per byte and counted once per occurrence, allowing a single voter to amplify their voting weight for an option. parseRawOptionId now deduplicates options while preserving order (ranking order for instant-runoff polls is kept intact). Additionally, single-choice polls now enforce exactly one option per ballot - malformed ballots are discarded instead of counted. Covered by new unit tests (parseRawOptionId.spec.ts) and integration tests (fetchTallyAmplification.spec.ts).
- Header padding fix (#109). Corrected paddings in the layout header component.
- pnpm v11 upgrade (#105, APP-240). Bumped pnpm to v11.5, moved config from .npmrc/package.json to pnpm-workspace.yaml, and updated CI workflows (audit, e2e, unit) accordingly.

### Steps for testing:

1. Install dependencies with pnpm v11 (corepack enable && pnpm install) and verify the app builds and runs.
2. Run the test suites: pnpm test (includes the new tally amplification and parseRawOptionId tests).
3. Verify poll tallies render correctly for single-choice, ranked-choice and approval polls, and that results match on-chain votes.
4. Confirm a ballot with duplicated options is counted only once per option (see fetchTallyAmplification.spec.ts scenarios).
5. Visually check the header paddings across desktop and mobile breakpoints.
6. Confirm CI workflows (unit, e2e, audit) pass with the new pnpm version.


### Any additional helpful information?:

- The tally fix addresses a vote-amplification vector reported via Immunefi (#82775). No legitimate poll format (single-choice, ranked, approval) ever repeats an option, so deduplication is safe for all formats.
- The pnpm upgrade requires pnpm v11 locally; older versions may fail to install due to the new pnpm-workspace.yaml config layout.
- Included PRs: #105, #109 plus commit e0105c5c directly on development.