### PR TITLE
Fix(polling): deduplicate ballot options in tally

### DIFF
--- a/modules/polling/api/__tests__/fetchTallyAmplification.spec.ts
+++ b/modules/polling/api/__tests__/fetchTallyAmplification.spec.ts
@@ -1,0 +1,195 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+/**
+ * Regression test for Immunefi #82775.
+ *
+ * The polling contract emits a raw optionId that the app decodes byte-by-byte into
+ * one ballot entry per byte. Without cardinality validation, a single-choice voter
+ * could submit a raw value whose bytes repeat the same option (e.g. 0x0101...01) and
+ * have their weight counted once per byte, multiplying their support for an option and
+ * flipping the active poll winner.
+ *
+ * These tests exercise fetchPollTally end-to-end and assert that:
+ *  - a duplicated-byte ballot is counted exactly once (no amplification, no winner flip);
+ *  - a single-choice ballot that decodes to multiple distinct options is discarded.
+ */
+
+import { PollInputFormat, PollResultDisplay, PollVictoryConditions } from 'modules/polling/polling.constants';
+import { Poll } from 'modules/polling/types';
+import { SupportedNetworks } from 'modules/web3/constants/networks';
+import { gqlRequest } from '../../../../modules/gql/gqlRequest';
+import { fetchPollTally } from '../fetchPollTally';
+import { Mock, vi } from 'vitest';
+
+vi.mock('modules/gql/gqlRequest');
+
+// 0x0101010101010101 -> decodes to [1, 1, 1, 1, 1, 1, 1, 1] before dedup (8x amplification attempt)
+const AMPLIFIED_YES_CHOICE = '72340172838076673';
+// 0x0201 -> decodes to [1, 2]: two distinct options, invalid for a single-choice poll
+const MULTI_OPTION_CHOICE = '513';
+
+const singleChoicePoll: Poll = {
+  pollId: 1,
+  options: {
+    '0': 'Abstain',
+    '1': 'Yes',
+    '2': 'No'
+  },
+  parameters: {
+    inputFormat: {
+      type: PollInputFormat.singleChoice,
+      abstain: [0],
+      options: []
+    },
+    resultDisplay: PollResultDisplay.singleVoteBreakdown,
+    victoryConditions: [
+      {
+        type: PollVictoryConditions.majority,
+        percent: 50
+      }
+    ]
+  }
+} as any as Poll;
+
+describe('Fetch tally - ballot amplification (Immunefi #82775)', () => {
+  it('counts a duplicated-byte single-choice ballot once and does not flip the winner', async () => {
+    (gqlRequest as Mock)
+      .mockResolvedValueOnce({}) // fetchDelegateAddresses
+      .mockResolvedValueOnce({ pollVotes: [] }) // mainnet voters
+      .mockResolvedValueOnce({
+        arbitrumPoll: {
+          votes: [
+            // Attacker: small weight (10 SKY) on "Yes", raw choice packs 8 repeated bytes.
+            { voter: { id: '0x123' }, choice: AMPLIFIED_YES_CHOICE },
+            // Honest voter: 60 SKY on "No".
+            { voter: { id: '0x456' }, choice: '2' }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        voters: [
+          { id: '0x123', v2VotingPowerChanges: [{ newBalance: '10000000000000000000' }] },
+          { id: '0x456', v2VotingPowerChanges: [{ newBalance: '60000000000000000000' }] }
+        ]
+      });
+
+    const result = await fetchPollTally(singleChoicePoll, SupportedNetworks.MAINNET);
+
+    const yes = result.results.find(r => r.optionId === 1);
+    const no = result.results.find(r => r.optionId === 2);
+
+    // "Yes" weight is counted once (10), not amplified to 80.
+    expect(yes?.skySupport).toBe('10');
+    expect(no?.skySupport).toBe('60');
+
+    // Honest majority stands: "No" wins, the attacker does not flip the poll.
+    expect(result.winner).toBe(2);
+    expect(result.winningOptionName).toBe('No');
+    expect(no?.winner).toBe(true);
+    expect(yes?.winner).toBe(false);
+    expect(result.numVoters).toBe(2);
+  });
+
+  it('discards a single-choice ballot that decodes to multiple distinct options', async () => {
+    (gqlRequest as Mock)
+      .mockResolvedValueOnce({}) // fetchDelegateAddresses
+      .mockResolvedValueOnce({ pollVotes: [] }) // mainnet voters
+      .mockResolvedValueOnce({
+        arbitrumPoll: {
+          votes: [
+            // Malformed single-choice ballot voting for options 1 and 2 at once, large weight.
+            { voter: { id: '0x123' }, choice: MULTI_OPTION_CHOICE },
+            // Honest voter: 60 SKY on "No".
+            { voter: { id: '0x456' }, choice: '2' }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        voters: [
+          { id: '0x123', v2VotingPowerChanges: [{ newBalance: '100000000000000000000' }] },
+          { id: '0x456', v2VotingPowerChanges: [{ newBalance: '60000000000000000000' }] }
+        ]
+      });
+
+    const result = await fetchPollTally(singleChoicePoll, SupportedNetworks.MAINNET);
+
+    const yes = result.results.find(r => r.optionId === 1);
+    const no = result.results.find(r => r.optionId === 2);
+
+    // The malformed ballot is dropped entirely: it contributes to neither option nor participation.
+    expect(yes?.skySupport).toBe('0');
+    expect(no?.skySupport).toBe('60');
+    expect(result.numVoters).toBe(1);
+    expect(result.totalSkyParticipation).toBe('60');
+    expect(result.winner).toBe(2);
+  });
+});
+
+// The amplification vector was never single-choice specific: an approval (choose-free)
+// poll counts every option in a ballot, so duplicated bytes would inflate an option there
+// too. The dedup in parseRawOptionId neutralizes this for every format, while legitimate
+// multi-option approval ballots must still count each distinct option once.
+const chooseFreePoll: Poll = {
+  pollId: 2,
+  options: {
+    '0': 'Abstain',
+    '1': 'Option A',
+    '2': 'Option B'
+  },
+  parameters: {
+    inputFormat: {
+      type: PollInputFormat.chooseFree,
+      abstain: [0],
+      options: []
+    },
+    resultDisplay: PollResultDisplay.approvalBreakdown,
+    victoryConditions: [
+      {
+        type: PollVictoryConditions.majority,
+        percent: 50
+      }
+    ]
+  }
+} as any as Poll;
+
+describe('Fetch tally - approval poll is not amplifiable (Immunefi #82775)', () => {
+  it('counts a duplicated-byte option once while still counting a legitimate multi-option ballot', async () => {
+    (gqlRequest as Mock)
+      .mockResolvedValueOnce({}) // fetchDelegateAddresses
+      .mockResolvedValueOnce({ pollVotes: [] }) // mainnet voters
+      .mockResolvedValueOnce({
+        arbitrumPoll: {
+          votes: [
+            // Honest voter legitimately approves both A and B (0x0201 -> [1, 2]), 40 SKY.
+            { voter: { id: '0x123' }, choice: MULTI_OPTION_CHOICE },
+            // Attacker approves only A with 8 repeated bytes, 10 SKY.
+            { voter: { id: '0x456' }, choice: AMPLIFIED_YES_CHOICE }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        voters: [
+          { id: '0x123', v2VotingPowerChanges: [{ newBalance: '40000000000000000000' }] },
+          { id: '0x456', v2VotingPowerChanges: [{ newBalance: '10000000000000000000' }] }
+        ]
+      });
+
+    const result = await fetchPollTally(chooseFreePoll, SupportedNetworks.MAINNET);
+
+    const optionA = result.results.find(r => r.optionId === 1);
+    const optionB = result.results.find(r => r.optionId === 2);
+
+    // Option A: 40 (honest) + 10 (attacker counted once) = 50, NOT 40 + 80.
+    expect(optionA?.skySupport).toBe('50');
+    // Option B: only the honest multi-option ballot counts it = 40.
+    expect(optionB?.skySupport).toBe('40');
+    expect(result.numVoters).toBe(2);
+    expect(result.totalSkyParticipation).toBe('50');
+  });
+});

--- a/modules/polling/api/fetchPollTally.ts
+++ b/modules/polling/api/fetchPollTally.ts
@@ -16,7 +16,7 @@ import { extractWinnerInstantRunoff } from './victory_conditions/instantRunoff';
 import { extractWinnerDefault } from './victory_conditions/default';
 import { InstantRunoffResults } from '../types/instantRunoff';
 import { extractSatisfiesComparison } from './victory_conditions/comparison';
-import { hasVictoryConditionInstantRunOff } from '../helpers/utils';
+import { hasVictoryConditionInstantRunOff, isInputFormatSingleChoice } from '../helpers/utils';
 import { fetchVotesByAddressForPoll } from './fetchVotesByAddress';
 import { calculatePercentage } from 'lib/utils';
 import { formatEther, parseEther } from 'viem';
@@ -73,7 +73,18 @@ export async function fetchPollTally(poll: Poll, network: SupportedNetworks): Pr
   });
 
   // Fetch votes for the poll
-  const votesByAddress = await fetchVotesByAddressForPoll(poll.pollId, ownerToDelegateMap, network);
+  const rawVotesByAddress = await fetchVotesByAddressForPoll(poll.pollId, ownerToDelegateMap, network);
+
+  // Cardinality guard: a single-choice poll must carry exactly one option per ballot.
+  // Ballots that decode to a different number of options are malformed for this format
+  // and are discarded rather than counted, so a voter cannot split or multiply their
+  // weight across options. Together with the deduplication in parseRawOptionId this
+  // closes the vote-amplification vector (Immunefi #82775). Other formats (ranked-choice,
+  // approval) legitimately carry multiple distinct options and are left untouched.
+  // isInputFormatSingleChoice also handles the legacy string-shaped inputFormat.
+  const votesByAddress = isInputFormatSingleChoice(poll.parameters)
+    ? rawVotesByAddress.filter(vote => vote.ballot.length === 1)
+    : rawVotesByAddress;
 
   // Abstain
   const abstain = poll.parameters.inputFormat.abstain ? poll.parameters.inputFormat.abstain : [0];

--- a/modules/polling/helpers/__tests__/parseRawOptionId.spec.ts
+++ b/modules/polling/helpers/__tests__/parseRawOptionId.spec.ts
@@ -1,0 +1,42 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import { parseRawOptionId } from '../parseRawOptionId';
+
+describe('parseRawOptionId', () => {
+  it('returns an empty ballot for an empty or undefined raw value', () => {
+    expect(parseRawOptionId(undefined)).toEqual([]);
+    expect(parseRawOptionId('')).toEqual([]);
+  });
+
+  it('decodes a single-option ballot', () => {
+    expect(parseRawOptionId('1')).toEqual([1]);
+    expect(parseRawOptionId('2')).toEqual([2]);
+  });
+
+  it('decodes a ranked ballot preserving order', () => {
+    // 0x030102 -> option ranking [2, 1, 3]
+    expect(parseRawOptionId('196866')).toEqual([2, 1, 3]);
+  });
+
+  // Regression: Immunefi #82775 - a raw optionId whose bytes repeat the same option
+  // must not inflate that option's weight. Duplicates are collapsed to a single entry.
+  it('deduplicates repeated options so weight cannot be multiplied', () => {
+    // 0x0101 -> [1, 1] before dedup
+    expect(parseRawOptionId('257')).toEqual([1]);
+    // 0x0101010101010101 -> [1, 1, 1, 1, 1, 1, 1, 1] before dedup (8x amplification attempt)
+    expect(parseRawOptionId('72340172838076673')).toEqual([1]);
+  });
+
+  it('deduplicates while keeping the first occurrence and ranking order', () => {
+    // 0x010201 -> [1, 2, 1] before dedup -> [1, 2]
+    expect(parseRawOptionId('66049')).toEqual([1, 2]);
+    // 0x02030103 -> [3, 1, 3, 2] before dedup -> [3, 1, 2]
+    expect(parseRawOptionId('33751299')).toEqual([3, 1, 2]);
+  });
+});

--- a/modules/polling/helpers/parseRawOptionId.ts
+++ b/modules/polling/helpers/parseRawOptionId.ts
@@ -16,5 +16,11 @@ export function parseRawOptionId(rawValue?: string): number[] {
     voteBallot = ballot.reverse();
   }
 
-  return voteBallot;
+  // A voter can never legitimately rank or approve the same option twice, in any
+  // poll format (single-choice, ranked-choice or approval). Duplicate bytes in the
+  // raw optionId would otherwise be counted once per occurrence during tallying,
+  // letting a single voter multiply their own weight for an option (Immunefi #82775).
+  // A Set preserves insertion order and keeps the first occurrence, so the ranking
+  // order used by instant-runoff polls is left intact.
+  return [...new Set(voteBallot)];
 }


### PR DESCRIPTION
A raw optionId whose bytes repeat the same option was decoded into one ballot entry per byte and counted once per entry, letting a single voter inflate their weight for an option. No poll format (single-choice, ranked, approval) ever legitimately repeats an option, so parseRawOptionId now deduplicates while preserving order (ranking order for instant-runoff is kept). Single-choice polls additionally require exactly one option per ballot; malformed ballots are discarded rather than counted.

### What does this PR do?

Fixes a vote-tally amplification flaw (Immunefi #82775). The polling contract emits a raw optionId that the app decodes byte-by-byte into one ballot entry per byte. Because the tally never validated ballot cardinality, a voter could submit a raw value whose bytes repeat the same option (e.g. 0x0101...01) and have their weight counted once per repeated byte, multiplying their support for a single option and flipping an active poll's winner.

Two layers of defense:

- Deduplication at the source (parseRawOptionId): a Set collapses repeated options while preserving insertion order, so a voter's weight is counted at most once per option. No poll format (single-choice, ranked-choice, approval) ever legitimately repeats an option, so this is safe for all types; first-occurrence ordering keeps instant-runoff rankings intact. This single chokepoint protects every downstream consumer (plurality, majority, IRV, aggregation, fetchAllCurrentVotes, and the UI).
- Cardinality guard for single-choice (fetchPollTally): single-choice polls must carry exactly one option per ballot; malformed ballots (more than one distinct option) are discarded rather than counted, so they contribute to neither any option nor participation. Uses isInputFormatSingleChoice, which also handles the legacy string-shaped inputFormat.

Note the vulnerability was not single-choice specific - approval (choose-free) polls count every option and were amplifiable the same way; the source-level dedup closes that too.

Files changed:
- modules/polling/helpers/parseRawOptionId.ts - dedup
- modules/polling/api/fetchPollTally.ts - single-choice cardinality guard
- modules/polling/helpers/__tests__/parseRawOptionId.spec.ts - new unit tests
- modules/polling/api/__tests__/fetchTallyAmplification.spec.ts - new regression tests

### Steps for testing:

pnpm install
pnpm exec vitest run \
  modules/polling/helpers/__tests__/parseRawOptionId.spec.ts \
  modules/polling/api/__tests__/fetchTallyAmplification.spec.ts \
  modules/polling/api/__tests__/fetchTally*.spec.ts

Expected: all pass (9 files, 31 tests), no regressions in the existing fetchTally* suites.

What the new tests assert:
- parseRawOptionId collapses repeated bytes (0x0101 and 0x0101010101010101 -> [1]) and dedups while preserving ranking order (0x02030103 -> [3, 1, 2]).
- Single-choice: an attacker with 10 SKY and a duplicated-byte ballot is counted once (10, not 80); the honest 60 SKY majority stands and the winner is not flipped.
- Single-choice: a ballot decoding to multiple distinct options is discarded (not counted for any option, excluded from participation).
- Approval (choose-free): a duplicated-byte option is counted once (50, not 120) while a legitimate two-option ballot still counts both.

Manual sanity check (optional): pick a live-ish poll on the deployed instance and confirm tallies are unchanged for normal ballots (dedup is a no-op for well-formed votes).

### Screenshots (if relevant):

N/A - no UI changes. This is tally/decoding logic only; poll result displays are unchanged for well-formed ballots.

### Any additional helpful information:

- Discard vs truncate for malformed single-choice: chosen to discard the vote rather than truncate to the first option. Rationale: a single-choice ballot with multiple distinct options is malformed, and the "first" option is an artifact of byte ordering, not a voter's declaration - guessing intent on an invalid on-chain vote is exactly the class of assumption that caused this bug. Fail-closed is safer for governance. Switching to truncate is a one-line change if the team prefers.
- Guard scope: intentionally limited to single-choice, the only format where "exactly one option" is correct. Ranked and approval legitimately carry multiple distinct options; their amplification risk is closed by the source-level dedup.
- Disclosure: this lives in the temporary private advisory fork. Keep it private until the fix is deployed to production - the diff itself reveals the exploit. Coordinate publish/merge and any CVE request with Immunefi after deployment.
- Follow-up worth considering (out of scope for this PR): check historical stored optionIdRaw/choice values for repeated bytes to determine whether any past poll result was actually affected and needs re-tallying or annotation.