### PR TITLE
fix Tenderly E2E transactions

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,6 +11,8 @@ NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
 NEXT_PUBLIC_SUBGRAPH_API_KEY=
 NEXT_PUBLIC_RPC_ARBITRUM_TESTNET=
 NEXT_PUBLIC_PROXY_ORIGIN=https://staging-proxy.sky.money
+TENDERLY_API_KEY=
+TENDERLY_MAINNET_FORK_VNET_ID=
 
 # this is used to determine which data sources (subgraphs and GitHub repos) to use
 NEXT_PUBLIC_VERCEL_ENV=development

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,7 @@ jobs:
       REDIS_URL: ${{ secrets.REDIS_URL }}
       USE_CACHE: true
       TENDERLY_API_KEY: ${{ secrets.TENDERLY_API_KEY }}
+      TENDERLY_MAINNET_FORK_VNET_ID: ${{ vars.TENDERLY_MAINNET_FORK_VNET_ID }}
       DEFENDER_API_SECRET_TESTNET: $${{ secrets.DEFENDER_API_SECRET_TESTNET}}
       DEFENDER_API_KEY_TESTNET: ${{ secrets.DEFENDER_API_KEY_TESTNET}}
     timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -95,12 +95,13 @@ The following configuration values can be added to the `.env` file:
 Required for e2e:
 
 - Set `TENDERLY_API_KEY` to be able to run e2e tests against forked network
+- Set `TENDERLY_MAINNET_FORK_VNET_ID` to the ID of the Tenderly VNet used as the fork source
 
 ### Tests
 
 The Governance portal includes two test suites: Vitest and E2E
 
-To run e2e, `TENDERLY_API_KEY` must be correcly configured.
+To run e2e, `TENDERLY_API_KEY` and `TENDERLY_MAINNET_FORK_VNET_ID` must be correctly configured.
 
 Install playwright
 `pnpm playwright install`

--- a/modules/web3/hooks/useWriteContractFlow.ts
+++ b/modules/web3/hooks/useWriteContractFlow.ts
@@ -51,6 +51,8 @@ export function useWriteContractFlow<
     ...useSimulateContractParamters
   } = parameters;
 
+  const { address: account, connector } = useAccount();
+
   // Prepare tx config
   const {
     data: simulationData,
@@ -59,6 +61,12 @@ export function useWriteContractFlow<
     error: simulationError
   } = useSimulateContract({
     ...useSimulateContractParamters,
+    // Tenderly Admin RPCs expose unlocked accounts through `eth_accounts`.
+    // Override that default only after wagmi has a connected wallet; passing
+    // `account: undefined` makes disconnected pages request a connector client.
+    ...(useSimulateContractParamters.account || account
+      ? { account: useSimulateContractParamters.account ?? account }
+      : {}),
     query: { ...useSimulateContractParamters.query, enabled, gcTime: gcTime || 30000 }
   } as UseSimulateContractParameters);
 
@@ -82,7 +90,6 @@ export function useWriteContractFlow<
   });
 
   // Workaround to get `txHash` from Safe connector
-  const { connector } = useAccount();
   const isSafeConnector = connector?.id === SAFE_CONNECTOR_ID;
 
   const eventHash = useWaitForSafeTxHash({

--- a/playwright/fixtures/delegate.ts
+++ b/playwright/fixtures/delegate.ts
@@ -73,7 +73,7 @@ export class DelegatePage {
     await this.confirmTransactionButton.click();
     await expect(this.confirmTransactionText).toBeVisible();
     await expect(this.congratsText).toBeVisible();
-    closeModal(this.page);
+    await closeModal(this.page);
   }
 
   async verifyDelegatedAmount(amount: string) {

--- a/playwright/fixtures/executive.ts
+++ b/playwright/fixtures/executive.ts
@@ -58,7 +58,7 @@ export class ExecutivePage {
     await this.depositSkyButton.click();
     await expect(this.confirmTransactionText).toBeVisible();
     await expect(this.transactionSuccessfulText).toBeVisible();
-    closeModal(this.page);
+    await closeModal(this.page);
   }
 
   async verifyLockedSky(amount: string) {

--- a/playwright/forkVnet.ts
+++ b/playwright/forkVnet.ts
@@ -12,7 +12,6 @@ import { mockRpcCalls } from './mock-rpc-call';
 dotenv.config();
 
 const displayName = process.env.CI ? 'ci-tests-testnet' : 'local-tests-testnet';
-const MAINNET_FORK_VNET_ID = 'bf27af19-1335-404a-9257-18affa774f5a';
 const RPC_READY_RETRIES = 5;
 
 const sendTenderlyRpc = async (rpcUrl: string, body: Record<string, unknown>) => {
@@ -93,6 +92,11 @@ const forkVnet = async (displayName: string) => {
   if (!displayName.length) {
     throw new Error('A display name is required for the virtual testnet');
   }
+  const sourceVnetId = process.env.TENDERLY_MAINNET_FORK_VNET_ID;
+  if (!sourceVnetId) {
+    throw new Error('TENDERLY_MAINNET_FORK_VNET_ID is required to fork the Tenderly virtual testnet');
+  }
+
   const res = await fetch('https://api.tenderly.co/api/v1/account/jetstreamgg/project/jetstream/vnets/fork', {
     headers: [
       ['accept', 'application/json, text/plain, */*'],
@@ -101,7 +105,7 @@ const forkVnet = async (displayName: string) => {
     ],
     method: 'POST',
     body: JSON.stringify({
-      vnet_id: MAINNET_FORK_VNET_ID,
+      vnet_id: sourceVnetId,
       display_name: displayName
     })
   });

--- a/playwright/forkVnet.ts
+++ b/playwright/forkVnet.ts
@@ -12,6 +12,33 @@ import { mockRpcCalls } from './mock-rpc-call';
 dotenv.config();
 
 const displayName = process.env.CI ? 'ci-tests-testnet' : 'local-tests-testnet';
+const MAINNET_FORK_VNET_ID = 'bf27af19-1335-404a-9257-18affa774f5a';
+const RPC_READY_RETRIES = 5;
+
+const sendTenderlyRpc = async (rpcUrl: string, body: Record<string, unknown>) => {
+  let lastError = 'unknown error';
+
+  for (let attempt = 1; attempt <= RPC_READY_RETRIES; attempt++) {
+    const response = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: {
+        accept: '*/*',
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    });
+    const result = await response.json();
+
+    if (response.ok && !result.error) return;
+
+    lastError = result.error?.message || `${response.status} ${response.statusText}`;
+    if (attempt < RPC_READY_RETRIES) {
+      await new Promise(resolve => setTimeout(resolve, attempt * 1000));
+    }
+  }
+
+  throw new Error(`Tenderly RPC failed after ${RPC_READY_RETRIES} attempts: ${lastError}`);
+};
 
 test.beforeAll(async () => {
   await forkVnet(displayName);
@@ -22,7 +49,9 @@ test.beforeAll(async () => {
 });
 
 test.beforeEach(async ({ page }) => {
-  await page.route('https://virtual.mainnet.rpc.tenderly.co/**', mockRpcCalls);
+  const file = await readFile('./tenderlyTestnetData.json', 'utf-8');
+  const { TENDERLY_RPC_URL } = JSON.parse(file);
+  await page.route(TENDERLY_RPC_URL, mockRpcCalls);
 });
 
 // test.afterAll(async () => {
@@ -33,25 +62,13 @@ export const setEthBalance = async (address: string, amount: string) => {
   const file = await readFile('./tenderlyTestnetData.json', 'utf-8');
   const { TENDERLY_RPC_URL } = JSON.parse(file);
   const hexAmount = toHex(parseEther(amount)).replace(/^0x0/, '0x');
-  const response = await fetch(TENDERLY_RPC_URL, {
-    method: 'POST',
-    headers: {
-      accept: '*/*',
-      'content-type': 'application/json'
-    },
-    body: JSON.stringify({
-      method: 'tenderly_setBalance',
-      params: [[address], hexAmount],
-      id: 42,
-      jsonrpc: '2.0'
-    })
+  await sendTenderlyRpc(TENDERLY_RPC_URL, {
+    method: 'tenderly_setBalance',
+    params: [[address], hexAmount],
+    id: 42,
+    jsonrpc: '2.0'
   });
-
-  if (!response.ok) {
-    throw new Error(`Error: ${response.statusText}`);
-  } else {
-    console.log('ETH balance set');
-  }
+  console.log('ETH balance set');
 };
 
 export const setErc20Balance = async (
@@ -63,52 +80,42 @@ export const setErc20Balance = async (
   const file = await readFile('./tenderlyTestnetData.json', 'utf-8');
   const { TENDERLY_RPC_URL } = JSON.parse(file);
 
-  const response = await fetch(TENDERLY_RPC_URL, {
-    method: 'POST',
-    headers: {
-      accept: '*/*',
-      'content-type': 'application/json'
-    },
-    body: JSON.stringify({
-      method: 'tenderly_setErc20Balance',
-      params: [tokenAddress, [address], toHex(parseUnits(amount, decimals))],
-      id: 42,
-      jsonrpc: '2.0'
-    })
+  await sendTenderlyRpc(TENDERLY_RPC_URL, {
+    method: 'tenderly_setErc20Balance',
+    params: [tokenAddress, [address], toHex(parseUnits(amount, decimals))],
+    id: 42,
+    jsonrpc: '2.0'
   });
-
-  if (!response.ok) {
-    throw new Error(`Error: ${response.statusText}`);
-  } else {
-    console.log('token balance set');
-  }
+  console.log('token balance set');
 };
 
 const forkVnet = async (displayName: string) => {
   if (!displayName.length) {
     throw new Error('A display name is required for the virtual testnet');
   }
-  const res = await fetch(
-    'https://api.tenderly.co/api/v1/account/jetstreamgg/project/jetstream/testnet/clone',
-    {
-      headers: [
-        ['accept', 'application/json, text/plain, */*'],
-        ['content-type', 'application/json'],
-        ['X-Access-Key', `${process.env.TENDERLY_API_KEY}`]
-      ],
-      method: 'POST',
-      body: JSON.stringify({
-        srcContainerId: '67d03866-3483-455a-a001-7f9f69b1c5d4', //id e2e-testing-apr-15-fork_apr_29
-        dstContainerDisplayName: displayName
-      })
-    }
-  );
+  const res = await fetch('https://api.tenderly.co/api/v1/account/jetstreamgg/project/jetstream/vnets/fork', {
+    headers: [
+      ['accept', 'application/json, text/plain, */*'],
+      ['content-type', 'application/json'],
+      ['X-Access-Key', `${process.env.TENDERLY_API_KEY}`]
+    ],
+    method: 'POST',
+    body: JSON.stringify({
+      vnet_id: MAINNET_FORK_VNET_ID,
+      display_name: displayName
+    })
+  });
 
   const testnetData = await res.json();
 
-  if (res.status !== 200) {
+  if (!res.ok) {
     console.error('There was an error while forking the virtual testnet:', testnetData);
     process.exit(1);
+  }
+
+  const adminRpc = testnetData.rpcs?.find((rpc: { name: string }) => rpc.name === 'Admin RPC');
+  if (!adminRpc?.url) {
+    throw new Error('Tenderly fork response did not include an Admin RPC URL');
   }
 
   console.log('Virtual Testnet successfully forked');
@@ -117,7 +124,7 @@ const forkVnet = async (displayName: string) => {
     './tenderlyTestnetData.json',
     JSON.stringify({
       TENDERLY_TESTNET_ID: testnetData.id,
-      TENDERLY_RPC_URL: testnetData.connectivityConfig.endpoints[0].uri
+      TENDERLY_RPC_URL: adminRpc.url
     })
   );
 };

--- a/playwright/polling.spec.ts
+++ b/playwright/polling.spec.ts
@@ -25,7 +25,7 @@ test('Adds polls to review and navigates to review page and votes with the legac
   pollingPage,
   executivePage
 }) => {
-  const selectedPollId = 1502;
+  const selectedPollId = 1505;
 
   // first we need to deposit SKY to chief since wallet balance no longer counts for poll voting
   await test.step('navigate to executives page', async () => {


### PR DESCRIPTION
### What does this PR do?

- Fixes Tenderly E2E transaction failures by:
- Migrating virtual testnet creation to Tenderly’s VNet fork API.
- Using the updated mainnet fork containing the current SKY governance contracts.
- Preparing transactions with the connected Wagmi account instead of Tenderly’s default unlocked account.
- Routing Playwright RPC mocks to the dynamically generated Admin RPC URL.
- Retrying balance funding while a new VNet becomes ready.
- Awaiting modal closure in the delegate and executive test fixtures.

### Steps for testing:
CI=true pnpm e2e delegates.spec.ts
CI=true pnpm e2e executives.spec.ts

### Screenshots (if relevant):

### Any additional helpful information?:
Tenderly Admin RPCs expose unlocked accounts through eth_accounts. Without an explicit simulation account, Viem prepared transactions for Tenderly’s first unlocked account instead of the Wagmi mock wallet, resulting in ConnectorAccountNotFoundError.
The account override is conditional so disconnected pages do not produce ConnectorNotConnectedError.
