### PR TITLE
fix(polling): filter votes to poll timeframe before tally deduplication

### DIFF
--- a/modules/polling/api/__tests__/fetchTallyAmplification.spec.ts
+++ b/modules/polling/api/__tests__/fetchTallyAmplification.spec.ts
@@ -34,6 +34,10 @@ const AMPLIFIED_YES_CHOICE = '72340172838076673';
 // 0x0201 -> decodes to [1, 2]: two distinct options, invalid for a single-choice poll
 const MULTI_OPTION_CHOICE = '513';
 
+// Poll window enclosing every mocked vote; votes outside it are not counted.
+const POLL_START = 50;
+const POLL_END = 200;
+
 const singleChoicePoll: Poll = {
   pollId: 1,
   options: {
@@ -64,11 +68,13 @@ describe('Fetch tally - ballot amplification (Immunefi #82775)', () => {
       .mockResolvedValueOnce({ pollVotes: [] }) // mainnet voters
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: POLL_START,
+          endDate: POLL_END,
           votes: [
             // Attacker: small weight (10 SKY) on "Yes", raw choice packs 8 repeated bytes.
-            { voter: { id: '0x123' }, choice: AMPLIFIED_YES_CHOICE },
+            { voter: { id: '0x123' }, choice: AMPLIFIED_YES_CHOICE, blockTime: 100 },
             // Honest voter: 60 SKY on "No".
-            { voter: { id: '0x456' }, choice: '2' }
+            { voter: { id: '0x456' }, choice: '2', blockTime: 100 }
           ]
         }
       })
@@ -102,11 +108,13 @@ describe('Fetch tally - ballot amplification (Immunefi #82775)', () => {
       .mockResolvedValueOnce({ pollVotes: [] }) // mainnet voters
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: POLL_START,
+          endDate: POLL_END,
           votes: [
             // Malformed single-choice ballot voting for options 1 and 2 at once, large weight.
-            { voter: { id: '0x123' }, choice: MULTI_OPTION_CHOICE },
+            { voter: { id: '0x123' }, choice: MULTI_OPTION_CHOICE, blockTime: 100 },
             // Honest voter: 60 SKY on "No".
-            { voter: { id: '0x456' }, choice: '2' }
+            { voter: { id: '0x456' }, choice: '2', blockTime: 100 }
           ]
         }
       })
@@ -165,11 +173,13 @@ describe('Fetch tally - approval poll is not amplifiable (Immunefi #82775)', () 
       .mockResolvedValueOnce({ pollVotes: [] }) // mainnet voters
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: POLL_START,
+          endDate: POLL_END,
           votes: [
             // Honest voter legitimately approves both A and B (0x0201 -> [1, 2]), 40 SKY.
-            { voter: { id: '0x123' }, choice: MULTI_OPTION_CHOICE },
+            { voter: { id: '0x123' }, choice: MULTI_OPTION_CHOICE, blockTime: 100 },
             // Attacker approves only A with 8 repeated bytes, 10 SKY.
-            { voter: { id: '0x456' }, choice: AMPLIFIED_YES_CHOICE }
+            { voter: { id: '0x456' }, choice: AMPLIFIED_YES_CHOICE, blockTime: 100 }
           ]
         }
       })

--- a/modules/polling/api/__tests__/fetchTallyApproval.spec.ts
+++ b/modules/polling/api/__tests__/fetchTallyApproval.spec.ts
@@ -48,12 +48,14 @@ describe('Fetch tally approval', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: '258' },
-            { voter: { id: '0x456' }, choice: '258' },
-            { voter: { id: '0x789' }, choice: '1' },
-            { voter: { id: '0xabc' }, choice: '4' },
-            { voter: { id: '0xdef' }, choice: '4' }
+            { voter: { id: '0x123' }, choice: '258', blockTime: 100 },
+            { voter: { id: '0x456' }, choice: '258', blockTime: 100 },
+            { voter: { id: '0x789' }, choice: '1', blockTime: 100 },
+            { voter: { id: '0xabc' }, choice: '4', blockTime: 100 },
+            { voter: { id: '0xdef' }, choice: '4', blockTime: 100 }
           ]
         }
       })
@@ -142,11 +144,13 @@ describe('Fetch tally approval', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: '258' },
-            { voter: { id: '0x456' }, choice: '258' },
-            { voter: { id: '0x789' }, choice: '4' },
-            { voter: { id: '0xabc' }, choice: '4' }
+            { voter: { id: '0x123' }, choice: '258', blockTime: 100 },
+            { voter: { id: '0x456' }, choice: '258', blockTime: 100 },
+            { voter: { id: '0x789' }, choice: '4', blockTime: 100 },
+            { voter: { id: '0xabc' }, choice: '4', blockTime: 100 }
           ]
         }
       })
@@ -234,7 +238,9 @@ describe('Fetch tally approval', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
-          votes: [{ voter: { id: '0x123' }, choice: '0' }]
+          startDate: 50,
+          endDate: 200,
+          votes: [{ voter: { id: '0x123' }, choice: '0', blockTime: 100 }]
         }
       })
       .mockResolvedValueOnce({

--- a/modules/polling/api/__tests__/fetchTallyCombined.spec.ts
+++ b/modules/polling/api/__tests__/fetchTallyCombined.spec.ts
@@ -86,10 +86,12 @@ describe('Fetch tally combined with other options', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: '1' },
-            { voter: { id: '0x456' }, choice: '2' },
-            { voter: { id: '0x789' }, choice: '3' }
+            { voter: { id: '0x123' }, choice: '1', blockTime: 100 },
+            { voter: { id: '0x456' }, choice: '2', blockTime: 100 },
+            { voter: { id: '0x789' }, choice: '3', blockTime: 100 }
           ]
         }
       })
@@ -166,10 +168,12 @@ describe('Fetch tally combined with other options', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: '1' },
-            { voter: { id: '0x456' }, choice: '2' },
-            { voter: { id: '0x789' }, choice: '3' }
+            { voter: { id: '0x123' }, choice: '1', blockTime: 100 },
+            { voter: { id: '0x456' }, choice: '2', blockTime: 100 },
+            { voter: { id: '0x789' }, choice: '3', blockTime: 100 }
           ]
         }
       })
@@ -283,11 +287,13 @@ describe('Fetch tally combined with other options', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: fromBuffer([1]) },
-            { voter: { id: '0x456' }, choice: fromBuffer([2].reverse()) },
-            { voter: { id: '0x789' }, choice: fromBuffer([3]) },
-            { voter: { id: '0xabc' }, choice: fromBuffer([4].reverse()) }
+            { voter: { id: '0x123' }, choice: fromBuffer([1]), blockTime: 100 },
+            { voter: { id: '0x456' }, choice: fromBuffer([2].reverse()), blockTime: 100 },
+            { voter: { id: '0x789' }, choice: fromBuffer([3]), blockTime: 100 },
+            { voter: { id: '0xabc' }, choice: fromBuffer([4].reverse()), blockTime: 100 }
           ]
         }
       })
@@ -377,11 +383,13 @@ describe('Fetch tally combined with other options', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: fromBuffer([1]) },
-            { voter: { id: '0x456' }, choice: fromBuffer([2].reverse()) },
-            { voter: { id: '0x789' }, choice: fromBuffer([3]) },
-            { voter: { id: '0xabc' }, choice: fromBuffer([4].reverse()) }
+            { voter: { id: '0x123' }, choice: fromBuffer([1]), blockTime: 100 },
+            { voter: { id: '0x456' }, choice: fromBuffer([2].reverse()), blockTime: 100 },
+            { voter: { id: '0x789' }, choice: fromBuffer([3]), blockTime: 100 },
+            { voter: { id: '0xabc' }, choice: fromBuffer([4].reverse()), blockTime: 100 }
           ]
         }
       })
@@ -510,11 +518,13 @@ describe('Fetch tally combined with other options', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: fromBuffer([1]) },
-            { voter: { id: '0x456' }, choice: fromBuffer([2].reverse()) },
-            { voter: { id: '0x789' }, choice: fromBuffer([3]) },
-            { voter: { id: '0xabc' }, choice: fromBuffer([4].reverse()) }
+            { voter: { id: '0x123' }, choice: fromBuffer([1]), blockTime: 100 },
+            { voter: { id: '0x456' }, choice: fromBuffer([2].reverse()), blockTime: 100 },
+            { voter: { id: '0x789' }, choice: fromBuffer([3]), blockTime: 100 },
+            { voter: { id: '0xabc' }, choice: fromBuffer([4].reverse()), blockTime: 100 }
           ]
         }
       })
@@ -604,11 +614,13 @@ describe('Fetch tally combined with other options', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: fromBuffer([1]) },
-            { voter: { id: '0x456' }, choice: fromBuffer([2].reverse()) },
-            { voter: { id: '0x789' }, choice: fromBuffer([3]) },
-            { voter: { id: '0xabc' }, choice: fromBuffer([4].reverse()) }
+            { voter: { id: '0x123' }, choice: fromBuffer([1]), blockTime: 100 },
+            { voter: { id: '0x456' }, choice: fromBuffer([2].reverse()), blockTime: 100 },
+            { voter: { id: '0x789' }, choice: fromBuffer([3]), blockTime: 100 },
+            { voter: { id: '0xabc' }, choice: fromBuffer([4].reverse()), blockTime: 100 }
           ]
         }
       })

--- a/modules/polling/api/__tests__/fetchTallyMajority.spec.ts
+++ b/modules/polling/api/__tests__/fetchTallyMajority.spec.ts
@@ -66,10 +66,12 @@ describe('Fetch tally majority', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: '1' },
-            { voter: { id: '0x456' }, choice: '2' },
-            { voter: { id: '0x789' }, choice: '3' }
+            { voter: { id: '0x123' }, choice: '1', blockTime: 100 },
+            { voter: { id: '0x456' }, choice: '2', blockTime: 100 },
+            { voter: { id: '0x789' }, choice: '3', blockTime: 100 }
           ]
         }
       })
@@ -146,10 +148,12 @@ describe('Fetch tally majority', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: '1' },
-            { voter: { id: '0x456' }, choice: '2' },
-            { voter: { id: '0x789' }, choice: '3' }
+            { voter: { id: '0x123' }, choice: '1', blockTime: 100 },
+            { voter: { id: '0x456' }, choice: '2', blockTime: 100 },
+            { voter: { id: '0x789' }, choice: '3', blockTime: 100 }
           ]
         }
       })

--- a/modules/polling/api/__tests__/fetchTallyPlurality.spec.ts
+++ b/modules/polling/api/__tests__/fetchTallyPlurality.spec.ts
@@ -48,12 +48,14 @@ describe('Fetch tally plurality', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: '1' },
-            { voter: { id: '0x456' }, choice: '1' },
-            { voter: { id: '0x789' }, choice: '0' },
-            { voter: { id: '0xabc' }, choice: '0' },
-            { voter: { id: '0x1aa' }, choice: '1' }
+            { voter: { id: '0x123' }, choice: '1', blockTime: 100 },
+            { voter: { id: '0x456' }, choice: '1', blockTime: 100 },
+            { voter: { id: '0x789' }, choice: '0', blockTime: 100 },
+            { voter: { id: '0xabc' }, choice: '0', blockTime: 100 },
+            { voter: { id: '0x1aa' }, choice: '1', blockTime: 100 }
           ]
         }
       })
@@ -142,14 +144,16 @@ describe('Fetch tally plurality', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: '1' },
-            { voter: { id: '0x456' }, choice: '1' },
-            { voter: { id: '0x789' }, choice: '0' },
-            { voter: { id: '0xabc' }, choice: '0' },
-            { voter: { id: '0x1aa' }, choice: '1' },
-            { voter: { id: '0x2bb' }, choice: '2' },
-            { voter: { id: '0x3cc' }, choice: '2' }
+            { voter: { id: '0x123' }, choice: '1', blockTime: 100 },
+            { voter: { id: '0x456' }, choice: '1', blockTime: 100 },
+            { voter: { id: '0x789' }, choice: '0', blockTime: 100 },
+            { voter: { id: '0xabc' }, choice: '0', blockTime: 100 },
+            { voter: { id: '0x1aa' }, choice: '1', blockTime: 100 },
+            { voter: { id: '0x2bb' }, choice: '2', blockTime: 100 },
+            { voter: { id: '0x3cc' }, choice: '2', blockTime: 100 }
           ]
         }
       })
@@ -240,6 +244,8 @@ describe('Fetch tally plurality', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: []
         }
       })
@@ -322,14 +328,16 @@ describe('Fetch tally plurality', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: '1' },
-            { voter: { id: '0x456' }, choice: '1' },
-            { voter: { id: '0x789' }, choice: '0' },
-            { voter: { id: '0xabc' }, choice: '0' },
-            { voter: { id: '0x1aa' }, choice: '1' },
-            { voter: { id: '0x2bb' }, choice: '2' },
-            { voter: { id: '0x3cc' }, choice: '0' }
+            { voter: { id: '0x123' }, choice: '1', blockTime: 100 },
+            { voter: { id: '0x456' }, choice: '1', blockTime: 100 },
+            { voter: { id: '0x789' }, choice: '0', blockTime: 100 },
+            { voter: { id: '0xabc' }, choice: '0', blockTime: 100 },
+            { voter: { id: '0x1aa' }, choice: '1', blockTime: 100 },
+            { voter: { id: '0x2bb' }, choice: '2', blockTime: 100 },
+            { voter: { id: '0x3cc' }, choice: '0', blockTime: 100 }
           ]
         }
       })

--- a/modules/polling/api/__tests__/fetchTallyRanked.spec.ts
+++ b/modules/polling/api/__tests__/fetchTallyRanked.spec.ts
@@ -74,10 +74,12 @@ describe('Fetch tally ranked', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: fromBuffer([1, 3].reverse()) }, // [1st choice, 2nd choice, ...]
-            { voter: { id: '0x456' }, choice: fromBuffer([3, 1].reverse()) },
-            { voter: { id: '0x789' }, choice: fromBuffer([2, 3].reverse()) }
+            { voter: { id: '0x123' }, choice: fromBuffer([1, 3].reverse()), blockTime: 100 }, // [1st choice, 2nd choice, ...]
+            { voter: { id: '0x456' }, choice: fromBuffer([3, 1].reverse()), blockTime: 100 },
+            { voter: { id: '0x789' }, choice: fromBuffer([2, 3].reverse()), blockTime: 100 }
           ]
         }
       })
@@ -163,10 +165,12 @@ describe('Fetch tally ranked', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: fromBuffer([1, 3].reverse()) }, // [1st choice, 2nd choice, ...]
-            { voter: { id: '0x456' }, choice: fromBuffer([3, 1].reverse()) },
-            { voter: { id: '0x789' }, choice: fromBuffer([2, 3].reverse()) }
+            { voter: { id: '0x123' }, choice: fromBuffer([1, 3].reverse()), blockTime: 100 }, // [1st choice, 2nd choice, ...]
+            { voter: { id: '0x456' }, choice: fromBuffer([3, 1].reverse()), blockTime: 100 },
+            { voter: { id: '0x789' }, choice: fromBuffer([2, 3].reverse()), blockTime: 100 }
           ]
         }
       })
@@ -255,11 +259,13 @@ describe('Fetch tally ranked', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: fromBuffer([1, 3].reverse()) }, // [1st choice, 2nd choice, ...]
-            { voter: { id: '0x456' }, choice: fromBuffer([3, 1].reverse()) },
-            { voter: { id: '0x789' }, choice: fromBuffer([2, 3].reverse()) },
-            { voter: { id: '0xabc' }, choice: fromBuffer([4, 1].reverse()) }
+            { voter: { id: '0x123' }, choice: fromBuffer([1, 3].reverse()), blockTime: 100 }, // [1st choice, 2nd choice, ...]
+            { voter: { id: '0x456' }, choice: fromBuffer([3, 1].reverse()), blockTime: 100 },
+            { voter: { id: '0x789' }, choice: fromBuffer([2, 3].reverse()), blockTime: 100 },
+            { voter: { id: '0xabc' }, choice: fromBuffer([4, 1].reverse()), blockTime: 100 }
           ]
         }
       })
@@ -348,12 +354,14 @@ describe('Fetch tally ranked', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: fromBuffer([1, 3].reverse()) },
-            { voter: { id: '0x456' }, choice: fromBuffer([3, 1].reverse()) },
+            { voter: { id: '0x123' }, choice: fromBuffer([1, 3].reverse()), blockTime: 100 },
+            { voter: { id: '0x456' }, choice: fromBuffer([3, 1].reverse()), blockTime: 100 },
             // option 4 should never get these votes since it's eliminated in the first round
-            { voter: { id: '0x789' }, choice: fromBuffer([2, 4].reverse()) },
-            { voter: { id: '0xabc' }, choice: fromBuffer([4, 1].reverse()) }
+            { voter: { id: '0x789' }, choice: fromBuffer([2, 4].reverse()), blockTime: 100 },
+            { voter: { id: '0xabc' }, choice: fromBuffer([4, 1].reverse()), blockTime: 100 }
           ]
         }
       })
@@ -452,11 +460,13 @@ describe('Fetch tally ranked', () => {
       })
       .mockResolvedValueOnce({
         arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
           votes: [
-            { voter: { id: '0x123' }, choice: fromBuffer([1]) },
-            { voter: { id: '0x456' }, choice: fromBuffer([2, 1].reverse()) },
-            { voter: { id: '0x789' }, choice: fromBuffer([3]) },
-            { voter: { id: '0xabc' }, choice: fromBuffer([4, 3].reverse()) }
+            { voter: { id: '0x123' }, choice: fromBuffer([1]), blockTime: 100 },
+            { voter: { id: '0x456' }, choice: fromBuffer([2, 1].reverse()), blockTime: 100 },
+            { voter: { id: '0x789' }, choice: fromBuffer([3]), blockTime: 100 },
+            { voter: { id: '0xabc' }, choice: fromBuffer([4, 3].reverse()), blockTime: 100 }
           ]
         }
       })

--- a/modules/polling/api/__tests__/fetchVotesByAddress.spec.ts
+++ b/modules/polling/api/__tests__/fetchVotesByAddress.spec.ts
@@ -69,4 +69,147 @@ describe('fetchVotesByAddressForPoll', () => {
       })
     );
   });
+
+  it('ignores a post-close ballot and keeps the voter’s in-window vote', async () => {
+    // Mirrors poll 1615: an in-window Arbitrum vote for option 2, then a mainnet vote for option 1
+    // cast after endDate. Dedupe keeps the highest blockTime, so without timeframe filtering the
+    // post-close ballot wins and inherits the voter's end-of-poll weight.
+    (gqlRequest as Mock)
+      .mockResolvedValueOnce({
+        pollVotes: [
+          {
+            voter: { id: '1-0xvoter', address: '0xvoter' },
+            choice: '1',
+            blockTime: 250,
+            txnHash: '0xpostclose'
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
+          votes: [
+            {
+              voter: { id: '42161-0xvoter', address: '0xvoter' },
+              choice: '2',
+              blockTime: 150,
+              txnHash: '0xinwindow'
+            }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        voters: [
+          {
+            id: '0xvoter',
+            address: '0xvoter',
+            v2VotingPowerChanges: [{ newBalance: '5000000000000000000' }]
+          }
+        ]
+      });
+
+    const votes = await fetchVotesByAddressForPoll(123, {}, SupportedNetworks.MAINNET);
+
+    expect(votes).toHaveLength(1);
+    expect(votes[0]).toEqual(
+      expect.objectContaining({
+        voter: '0xvoter',
+        hash: '0xinwindow',
+        ballot: [2],
+        skySupport: '5'
+      })
+    );
+  });
+
+  it('excludes voters who only voted outside the poll window', async () => {
+    // Mirrors polls 1504/1505/1507: addresses that never voted in-window are absent from the weight
+    // lookup, so they land in the tally with 0 SKY and inflate numVoters.
+    (gqlRequest as Mock)
+      .mockResolvedValueOnce({
+        pollVotes: [
+          {
+            voter: { id: '1-0xlate', address: '0xlate' },
+            choice: '1',
+            blockTime: 500,
+            txnHash: '0xlate'
+          },
+          {
+            voter: { id: '1-0xearly', address: '0xearly' },
+            choice: '1',
+            blockTime: 10,
+            txnHash: '0xearly'
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        arbitrumPoll: {
+          startDate: 50,
+          endDate: 200,
+          votes: [
+            {
+              voter: { id: '42161-0xreal', address: '0xreal' },
+              choice: '1',
+              blockTime: 120,
+              txnHash: '0xreal'
+            }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        voters: [
+          {
+            id: '0xreal',
+            address: '0xreal',
+            v2VotingPowerChanges: [{ newBalance: '5000000000000000000' }]
+          }
+        ]
+      });
+
+    const votes = await fetchVotesByAddressForPoll(123, {}, SupportedNetworks.MAINNET);
+
+    expect(votes.map(vote => vote.voter)).toEqual(['0xreal']);
+  });
+
+  it('treats string blockTime and poll dates numerically', async () => {
+    // Envio returns numeric columns as strings; a lexicographic comparison would let this through.
+    (gqlRequest as Mock)
+      .mockResolvedValueOnce({
+        pollVotes: [
+          {
+            voter: { id: '1-0xlate', address: '0xlate' },
+            choice: '1',
+            blockTime: '1000',
+            txnHash: '0xlate'
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        arbitrumPoll: {
+          startDate: '50',
+          endDate: '200',
+          votes: [
+            {
+              voter: { id: '42161-0xreal', address: '0xreal' },
+              choice: '1',
+              blockTime: '120',
+              txnHash: '0xreal'
+            }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        voters: [
+          {
+            id: '0xreal',
+            address: '0xreal',
+            v2VotingPowerChanges: [{ newBalance: '5000000000000000000' }]
+          }
+        ]
+      });
+
+    const votes = await fetchVotesByAddressForPoll(123, {}, SupportedNetworks.MAINNET);
+
+    expect(votes.map(vote => vote.voter)).toEqual(['0xreal']);
+  });
 });

--- a/modules/polling/api/fetchVotesByAddress.ts
+++ b/modules/polling/api/fetchVotesByAddress.ts
@@ -86,24 +86,33 @@ export async function fetchVotesByAddressForPoll(
   ]);
 
   const arbitrumPoll = arbitrumVotersResponse.arbitrumPoll;
-  const startUnix = arbitrumPoll?.startDate ?? Number.NEGATIVE_INFINITY;
-  const endUnix = arbitrumPoll?.endDate ?? Number.POSITIVE_INFINITY;
+  // Envio returns numeric fields as strings; coerce so the window comparisons stay numeric.
+  const startUnix =
+    arbitrumPoll?.startDate != null ? Number(arbitrumPoll.startDate) : Number.NEGATIVE_INFINITY;
+  const endUnix = arbitrumPoll?.endDate != null ? Number(arbitrumPoll.endDate) : Number.POSITIVE_INFINITY;
 
   const mainnetVotes = mainnetVotersResponse.pollVotes || [];
   const arbitrumVotes = arbitrumPoll?.votes || [];
 
-  const isVoteWithinPollTimeframe = vote => vote.blockTime >= startUnix && vote.blockTime <= endUnix;
+  const isVoteWithinPollTimeframe = vote => {
+    const blockTime = Number(vote.blockTime);
+    return blockTime >= startUnix && blockTime <= endUnix;
+  };
   const getVoterAddress = (voter: VoterData | VoterWithWeight) =>
     voter.address || stripChainIdPrefix(voter.id);
   const mapToDelegateAddress = (voterAddress: string) => delegateOwnerToAddress[voterAddress] || voterAddress;
 
+  // Neither polling contract enforces the poll window on-chain, so the indexer returns votes cast
+  // outside it. Drop them before the dedupe below, which keeps the latest blockTime per voter and
+  // would otherwise let a post-close ballot replace a legitimate one.
+  const mainnetVotesInPollTimeframe = mainnetVotes.filter(isVoteWithinPollTimeframe);
+  const arbitrumVotesInPollTimeframe = arbitrumVotes.filter(isVoteWithinPollTimeframe);
+
   // Normalize voters to the delegate contract address used for dedupe and weight lookup.
-  const mainnetVoterAddresses = mainnetVotes
-    .filter(isVoteWithinPollTimeframe)
-    .map(vote => getVoterAddress(vote.voter));
-  const arbitrumVoterAddresses = arbitrumVotes
-    .filter(isVoteWithinPollTimeframe)
-    .map(vote => mapToDelegateAddress(getVoterAddress(vote.voter)));
+  const mainnetVoterAddresses = mainnetVotesInPollTimeframe.map(vote => getVoterAddress(vote.voter));
+  const arbitrumVoterAddresses = arbitrumVotesInPollTimeframe.map(vote =>
+    mapToDelegateAddress(getVoterAddress(vote.voter))
+  );
 
   const allVoterAddresses = [...mainnetVoterAddresses, ...arbitrumVoterAddresses];
 
@@ -113,11 +122,11 @@ export async function fetchVotesByAddressForPoll(
     voter: { ...vote.voter, id: voterAddress, address: voterAddress }
   });
 
-  const mainnetVotesWithChainId = mainnetVotes.map(vote =>
+  const mainnetVotesWithChainId = mainnetVotesInPollTimeframe.map(vote =>
     normalizeVoteVoterAddress(vote, mainnetChainId)
   );
 
-  const arbitrumVotesTaggedWithChainId = arbitrumVotes.map(vote => {
+  const arbitrumVotesTaggedWithChainId = arbitrumVotesInPollTimeframe.map(vote => {
     const mappedAddress = mapToDelegateAddress(getVoterAddress(vote.voter));
     return normalizeVoteVoterAddress(vote, arbitrumChainId, mappedAddress);
   });


### PR DESCRIPTION
## Summary

In `fetchVotesByAddressForPoll`, the poll-timeframe filter was applied when building the voter address lists for the SKY weight lookup, but the vote arrays that feed deduplication were built from the unfiltered sources. This derives both from the same filtered arrays, so votes with a `blockTime` outside the poll window are consistently excluded before deduplication and the tally.

`blockTime` and the poll dates are coerced with `Number()` — the indexer returns them as strings, and the previous comparison relied on numeric strings sorting lexicographically.

## Testing

- New `fetchVotesByAddress` specs covering in-window/out-of-window vote handling and per-voter deduplication
- Updated tally specs (plurality, majority, approval, ranked, combined, amplification) for the filtered path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
